### PR TITLE
Add oauth-authz-req+jwt to RequestObject JWT header

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/SignRequestObjectNimbus.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/SignRequestObjectNimbus.kt
@@ -15,10 +15,7 @@
  */
 package eu.europa.ec.eudi.verifier.endpoint.adapter.out.jose
 
-import com.nimbusds.jose.EncryptionMethod
-import com.nimbusds.jose.JWEAlgorithm
-import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.*
 import com.nimbusds.jose.crypto.RSASSASigner
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.RSAKey
@@ -59,7 +56,10 @@ class SignRequestObjectNimbus(private val rsaJWK: RSAKey) : SignRequestObject {
         clientMetaData: ClientMetaData,
         requestObject: RequestObject,
     ): Result<Jwt> = runCatching {
-        val header = JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaJWK.keyID).build()
+        val header = JWSHeader.Builder(JWSAlgorithm.RS256)
+            .keyID(rsaJWK.keyID)
+            .type(JOSEObjectType(AuthReqJwt))
+            .build()
         val claimSet = asClaimSet(toNimbus(clientMetaData), requestObject)
         with(SignedJWT(header, claimSet)) {
             sign(RSASSASigner(rsaJWK))
@@ -121,5 +121,9 @@ class SignRequestObjectNimbus(private val rsaJWK: RSAKey) : SignRequestObject {
             jwkSetURI = vJwkSetURI?.toURI()
             setCustomField("subject_syntax_types_supported", c.subjectSyntaxTypesSupported)
         }
+    }
+
+    companion object {
+        const val AuthReqJwt = "oauth-authz-req+jwt"
     }
 }


### PR DESCRIPTION
[RFC9101](https://www.rfc-editor.org/rfc/rfc9101.txt) in section `10.8 Cross-JWT Confusion` proposes 
the following:

Another way to prevent cross-JWT confusion is to use explicit typing,
 as described in Section 3.11 of [RFC8725].  One would explicitly type
a Request Object by including a "typ" Header Parameter with the value
 "oauth-authz-req+jwt" (which is registered in Section 9.4.1)
 
 This PR implements this recommendation