### PR TITLE
Defined vp_token as string (was json)

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/WalletApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/WalletApi.kt
@@ -23,8 +23,6 @@ import eu.europa.ec.eudi.verifier.endpoint.domain.EmbedOption
 import eu.europa.ec.eudi.verifier.endpoint.domain.RequestId
 import eu.europa.ec.eudi.verifier.endpoint.port.input.*
 import eu.europa.ec.eudi.verifier.endpoint.port.input.QueryResponse.*
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonObject
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
@@ -111,7 +109,7 @@ class WalletApi(
             AuthorisationResponseTO(
                 state = getFirst("state"),
                 idToken = getFirst("id_token"),
-                vpToken = getFirst("vp_token")?.let { Json.parseToJsonElement(it).jsonObject },
+                vpToken = getFirst("vp_token"),
                 presentationSubmission = getFirst("presentation_submission")?.let {
                     PresentationExchange.jsonParser.decodePresentationSubmission(it).getOrThrow()
                 },

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/Presentation.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/Presentation.kt
@@ -17,7 +17,6 @@ package eu.europa.ec.eudi.verifier.endpoint.domain
 
 import eu.europa.ec.eudi.prex.PresentationDefinition
 import eu.europa.ec.eudi.prex.PresentationSubmission
-import kotlinx.serialization.json.JsonObject
 import java.time.Clock
 import java.time.Instant
 
@@ -92,7 +91,7 @@ sealed interface WalletResponse {
     }
 
     data class VpToken(
-        val vpToken: JsonObject,
+        val vpToken: String,
         val presentationSubmission: PresentationSubmission,
     ) : WalletResponse {
         init {
@@ -102,7 +101,7 @@ sealed interface WalletResponse {
 
     data class IdAndVpToken(
         val idToken: Jwt,
-        val vpToken: JsonObject,
+        val vpToken: String,
         val presentationSubmission: PresentationSubmission,
     ) : WalletResponse {
         init {

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/GetWalletResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/GetWalletResponse.kt
@@ -24,7 +24,6 @@ import eu.europa.ec.eudi.verifier.endpoint.port.input.QueryResponse.*
 import eu.europa.ec.eudi.verifier.endpoint.port.out.persistence.LoadPresentationById
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Represent the [WalletResponse] as returned by the wallet
@@ -33,7 +32,7 @@ import kotlinx.serialization.json.JsonObject
 @SerialName("wallet_response")
 data class WalletResponseTO(
     @SerialName("id_token") val idToken: String? = null,
-    @SerialName("vp_token") val vpToken: JsonObject? = null,
+    @SerialName("vp_token") val vpToken: String? = null,
     @SerialName("presentation_submission") val presentationSubmission: PresentationSubmission? = null,
     @SerialName("error") val error: String? = null,
     @SerialName("error_description") val errorDescription: String? = null,

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/PostWalletResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/PostWalletResponse.kt
@@ -19,7 +19,6 @@ import eu.europa.ec.eudi.prex.PresentationSubmission
 import eu.europa.ec.eudi.verifier.endpoint.domain.*
 import eu.europa.ec.eudi.verifier.endpoint.port.out.persistence.LoadPresentationByRequestId
 import eu.europa.ec.eudi.verifier.endpoint.port.out.persistence.StorePresentation
-import kotlinx.serialization.json.JsonObject
 import java.time.Clock
 
 /**
@@ -31,7 +30,7 @@ data class AuthorisationResponseTO(
     val error: String? = null,
     val errorDescription: String? = null,
     val idToken: String? = null,
-    val vpToken: JsonObject? = null,
+    val vpToken: String? = null,
     val presentationSubmission: PresentationSubmission? = null,
 )
 


### PR DESCRIPTION
`PostWalletResponse` use-case incorrectly models the `vp_token` of a  OpenId4VP response as `JsonObject`

This PR change the `vp_token` into a simple string in order to keep it opaque.