### PR TITLE
Move dependencies to version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,30 @@
+[versions]
+coroutines = "1.7.3"
+dokka = "1.9.0"
+kotlin = "1.9.10"
+foojay = "0.7.0"
+springboot = "3.1.4"
+springDependencyManagement = "1.1.3"
+spotless = "6.20.0"
+java = "17"
+kotlinxSerialization = "1.6.0"
+oauth2OidcSdk="10.13.2"
+presentationExchange="0.1.0-SNAPSHOT"
+ktlintVersion="0.50.0"
+
+
+[libraries]
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+nimbusds-oauth2-oidc-sdk = {module ="com.nimbusds:oauth2-oidc-sdk", version.ref="oauth2OidcSdk"}
+presentation-exchange =  {module ="eu.europa.ec.eudi:eudi-lib-jvm-presentation-exchange-kt", version.ref="presentationExchange"}
+
+[plugins]
+foojay-resolver-convention = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojay" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+spring-boot = { id = "org.springframework.boot", version.ref = "springboot" }
+spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "springDependencyManagement" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-plugin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
+kotlin-plugin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+


### PR DESCRIPTION
This PR moves the dependencies of the project to a [version catalog](https://docs.gradle.org/current/userguide/platforms.html)