### PR TITLE
Update docker image build and publication.

### DIFF
--- a/.github/workflows/publish-to-container-registry.yml
+++ b/.github/workflows/publish-to-container-registry.yml
@@ -51,12 +51,10 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
-
+            type=semver,pattern=v{{version}}
+            type=edge
+      - name: Debug
+        run: echo ${{ steps.meta.outputs }}
       - name: Build and publish with Gradle Wrapper
         uses: gradle/gradle-build-action@v2.4.2
         if: github.event_name != 'pull_request'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,18 +61,22 @@ springBoot {
 }
 
 tasks.named<BootBuildImage>("bootBuildImage") {
-    imageName.set("${project.name}")
+    imageName.set("$group/${project.name}")
     publish.set(false)
-    docker {
-        publishRegistry {
-            url = System.getenv("REGISTRY_URL")
-            username = System.getenv("REGISTRY_USERNAME")
-            password = System.getenv("REGISTRY_PASSWORD")
-        }
-    }
     // get the BP_OCI_* from env, for https://github.com/paketo-buildpacks/image-labels
     // get the BP_JVM_* from env, jlink optimisation
     environment.set(System.getenv())
+    val env = environment.get()
+    docker {
+        publishRegistry {
+            env["REGISTRY_URL"]?.let { url = it }
+            env["REGISTRY_USERNAME"]?.let { username = it }
+            env["REGISTRY_PASSWORD"]?.let { password = it }
+        }
+        env["DOCKER_METADATA_OUTPUT_TAGS"]?.let { tagStr ->
+            tags = tagStr.split(delimiters = arrayOf("\n", " ")).onEach { println("Tag: $it") }
+        }
+    }
 }
 
 spotless {


### PR DESCRIPTION
Successful execution can be found [here](https://github.com/niscy-eudiw/eudi-srv-web-verifier-endpoint-23220-4-kt/actions/runs/6956829085/job/18928476398)

When trying to trigger the action directly, the workflow fails since it type=edge is expected to be run on the `main` branch. Test execution [here](https://github.com/niscy-eudiw/eudi-srv-web-verifier-endpoint-23220-4-kt/actions/runs/6956868293/job/18928598213)

Closes #69 