### PR TITLE
Remove snapshot repo from gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,10 +19,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven {
-        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-        mavenContent { snapshotsOnly() }
-    }
     mavenLocal()
 }
 


### PR DESCRIPTION
After publication there is no good reason to have SNAPSHOT dependencies repository enabled.
Application can use stable releases of EUDIW libs.

This PR removes the snapshot repository from gradle