### PR TITLE
Remove dokka plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ import kotlin.jvm.optionals.getOrNull
 
 plugins {
     base
-    alias(libs.plugins.dokka)
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
     alias(libs.plugins.kotlin.jvm)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 coroutines = "1.8.0"
-dokka = "1.9.10"
 kotlin = "1.9.23"
 foojay = "0.8.0"
 springboot = "3.2.3"
@@ -29,7 +28,6 @@ arrow-fx-coroutines = { module = "io.arrow-kt:arrow-fx-coroutines", version.ref 
 
 [plugins]
 foojay-resolver-convention = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojay" }
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 spring-boot = { id = "org.springframework.boot", version.ref = "springboot" }
 spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "springDependencyManagement" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
This PR removes from build scripts the dokka plugin.
Reason is that this project is not a library hence it doesn't publish javadoc