### PR TITLE
Include also the attributes values of validated MSO MDoc documents.

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/UtilityApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/UtilityApi.kt
@@ -45,11 +45,11 @@ internal class UtilityApi(
             }
         return when (val result = validateMsoMdocDeviceResponse(vpToken)) {
             is DeviceResponseValidationResult.Valid ->
-                ok().bodyValueAndAwait(result.documents)
+                ok().json()
+                    .bodyValueAndAwait(result.documents)
 
             is DeviceResponseValidationResult.Invalid ->
-                badRequest()
-                    .json()
+                badRequest().json()
                     .bodyValueAndAwait(result.error)
         }
     }

--- a/src/main/resources/public/openapi.json
+++ b/src/main/resources/public/openapi.json
@@ -1030,15 +1030,7 @@
           "attributes": {
             "type": "object",
             "nullable": false,
-            "additionalProperties": {
-              "type": "array",
-              "nullable": false,
-              "items": {
-                "type": "string",
-                "nullable": false
-              },
-              "minItems": 0
-            }
+            "additionalProperties": true
           }
         },
         "required": [
@@ -1509,9 +1501,9 @@
           {
             "docType": "eu.europa.ec.eudi.pid.1",
             "attributes": {
-              "eu.europa.ec.eudi.pid.1": [
-                "age_over_18"
-              ]
+              "eu.europa.ec.eudi.pid.1": {
+                "age_over_18": true
+              }
             }
           }
         ]


### PR DESCRIPTION
MSO MDoc DeviceResponse validation API has been updated to now also include the attribute values of validation MSO MDoc Documents.
i.e.
```json
[
    {
        "docType": "eu.europa.ec.eudi.pid.1",
        "attributes": {
            "eu.europa.ec.eudi.pid.1": {
                "age_over_18": true
            }
        }
    }
]
```