### PR TITLE
Remove `client_id_scheme`

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,8 +497,8 @@ Variable: `SERVER_PORT`
 Description: Port for the HTTP listener of the Verifier Endpoint application  
 Default value: `8080`
 
-Variable: `VERIFIER_CLIENTID`  
-Description: Client Id of the Verifier Endpoint application  
+Variable: `VERIFIER_ORIGINALCLIENTID`  
+Description: Client Id of the Verifier Endpoint application **without** the Client Id Scheme prefix   
 Default value: `Verifier`
 
 Variable: `VERIFIER_CLIENTIDSCHEME`  

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/RequestObject.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/RequestObject.kt
@@ -22,7 +22,7 @@ import java.time.Clock
 import java.time.Instant
 
 internal data class RequestObject(
-    val clientIdScheme: ClientIdScheme,
+    val verifierId: VerifierId,
     val responseType: List<String>,
     val presentationDefinitionUri: URL?,
     val presentationDefinition: PresentationDefinition? = null,
@@ -82,7 +82,7 @@ internal fun requestObjectFromDomain(
     }
 
     return RequestObject(
-        clientIdScheme = verifierConfig.clientIdScheme,
+        verifierId = verifierConfig.verifierId,
         scope = scope,
         idTokenType = idTokenType,
         presentationDefinitionUri = presentationDefinitionUri,

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransaction.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransaction.kt
@@ -119,7 +119,7 @@ enum class ValidationError {
 @Serializable
 data class JwtSecuredAuthorizationRequestTO(
     @Required @SerialName("transaction_id") val transactionId: String,
-    @Required @SerialName("client_id") val clientId: String,
+    @Required @SerialName("client_id") val clientId: ClientId,
     @SerialName("request") val request: String? = null,
     @SerialName("request_uri") val requestUri: String?,
 ) {
@@ -225,7 +225,7 @@ class InitTransactionLive(
                 val requestObjectRetrieved = requestedPresentation.retrieveRequestObject(clock).getOrThrow()
                 requestObjectRetrieved to JwtSecuredAuthorizationRequestTO(
                     requestedPresentation.id.value,
-                    verifierConfig.clientIdScheme.clientId,
+                    verifierConfig.verifierId.clientId,
                     jwt,
                     null,
                 )
@@ -235,7 +235,7 @@ class InitTransactionLive(
                 val requestUri = requestJarOption.buildUrl(requestedPresentation.requestId).toExternalForm()
                 requestedPresentation to JwtSecuredAuthorizationRequestTO(
                     requestedPresentation.id.value,
-                    verifierConfig.clientIdScheme.clientId,
+                    verifierConfig.verifierId.clientId,
                     null,
                     requestUri,
                 )

--- a/src/main/resources/application-san-dns.properties
+++ b/src/main/resources/application-san-dns.properties
@@ -1,7 +1,7 @@
 #
 # Verifier options
 #
-verifier.clientId=localhost
+verifier.originalClientId=localhost
 verifier.clientIdScheme=x509_san_dns
 verifier.jar.signing.algorithm=ES512
 verifier.jar.signing.key=LoadFromKeystore

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,7 @@ spring.webflux.webjars-path-pattern=/webjars/**
 #
 # Verifier options
 #
-verifier.clientId=Verifier
+verifier.originalClientId=Verifier
 verifier.clientIdScheme=pre-registered
 verifier.jar.signing.algorithm=RS256
 verifier.jar.signing.key=GenerateRandom

--- a/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/TestContext.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/TestContext.kt
@@ -69,7 +69,7 @@ object TestContext {
         jarmOption = ParseJarmOptionNimbus(null, JWEAlgorithm.ECDH_ES.name, "A256GCM")!!,
     )
     private val jarSigningConfig: SigningConfig = SigningConfig(rsaJwk, JWSAlgorithm.RS256)
-    val clientIdScheme = ClientIdScheme.X509SanDns("client-id", jarSigningConfig)
+    val verifierId = VerifierId.X509SanDns("client-id", jarSigningConfig)
     val singRequestObject: SignRequestObjectNimbus = SignRequestObjectNimbus()
     val singRequestObjectVerifier = RSASSAVerifier(rsaJwk)
     private val repo = PresentationInMemoryRepo()

--- a/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/SignRequestObjectNimbusTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/SignRequestObjectNimbusTest.kt
@@ -44,12 +44,12 @@ class SignRequestObjectNimbusTest {
     private val signRequestObject = TestContext.singRequestObject
     private val verifier = TestContext.singRequestObjectVerifier
     private val clientMetaData = TestContext.clientMetaData
-    private val clientIdScheme = TestContext.clientIdScheme
+    private val verifierId = TestContext.verifierId
 
     @Test
     fun `given a request object, it should be signed and decoded`() {
         val requestObject = RequestObject(
-            clientIdScheme = clientIdScheme,
+            verifierId = verifierId,
             responseType = listOf("vp_token", "id_token"),
             presentationDefinitionUri = null,
             presentationDefinition = PresentationExchange.jsonParser.decodePresentationDefinition(pd).getOrThrow(),
@@ -95,8 +95,7 @@ class SignRequestObjectNimbusTest {
     }
 
     private fun assertEqualsRequestObjectJWTClaimSet(r: RequestObject, c: JWTClaimsSet) {
-        assertEquals(r.clientIdScheme.clientId, c.getStringClaim("client_id"))
-        assertEquals(r.clientIdScheme.name, c.getStringClaim("client_id_scheme"))
+        assertEquals(r.verifierId.clientId, c.getStringClaim("client_id"))
         assertEquals(r.responseType.joinToString(separator = " "), c.getStringClaim("response_type"))
         assertEquals(r.presentationDefinitionUri?.toExternalForm(), c.getStringClaim("presentation_definition_uri"))
         assertEquals(r.presentationDefinition, c.getJSONObjectClaim("presentation_definition"))

--- a/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransactionTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransactionTest.kt
@@ -34,7 +34,7 @@ class InitTransactionTest {
 
     private val uri = URL("https://foo")
     private val verifierConfig = VerifierConfig(
-        clientIdScheme = TestContext.clientIdScheme,
+        verifierId = TestContext.verifierId,
         requestJarOption = EmbedOption.ByValue,
         presentationDefinitionEmbedOption = EmbedOption.ByValue,
         responseUriBuilder = { _ -> uri },
@@ -60,7 +60,7 @@ class InitTransactionTest {
             )
 
             val jwtSecuredAuthorizationRequest = useCase(input).getOrElse { fail("Unexpected $it") }
-            assertEquals(jwtSecuredAuthorizationRequest.clientId, verifierConfig.clientIdScheme.clientId)
+            assertEquals(jwtSecuredAuthorizationRequest.clientId, verifierConfig.verifierId.clientId)
             assertNotNull(jwtSecuredAuthorizationRequest.request)
             assertTrue {
                 loadPresentationById(testTransactionId)?.let { it is Presentation.RequestObjectRetrieved } ?: false
@@ -72,7 +72,7 @@ class InitTransactionTest {
         runTest {
             val uri = URL("https://foo")
             val verifierConfig = VerifierConfig(
-                clientIdScheme = TestContext.clientIdScheme,
+                verifierId = TestContext.verifierId,
                 requestJarOption = EmbedOption.ByReference { _ -> uri },
                 presentationDefinitionEmbedOption = EmbedOption.ByValue,
                 responseUriBuilder = { _ -> URL("https://foo") },
@@ -95,7 +95,7 @@ class InitTransactionTest {
             )
 
             val jwtSecuredAuthorizationRequest = useCase(input).getOrElse { fail("Unexpected $it") }
-            assertEquals(jwtSecuredAuthorizationRequest.clientId, verifierConfig.clientIdScheme.clientId)
+            assertEquals(jwtSecuredAuthorizationRequest.clientId, verifierConfig.verifierId.clientId)
             assertEquals(uri.toExternalForm(), jwtSecuredAuthorizationRequest.requestUri)
             assertTrue {
                 loadPresentationById(testTransactionId)?.let { it is Presentation.Requested } ?: false
@@ -148,7 +148,7 @@ class InitTransactionTest {
             )
 
             val jwtSecuredAuthorizationRequest = useCase(input).getOrElse { fail("Unexpected $it") }
-            assertEquals(jwtSecuredAuthorizationRequest.clientId, verifierConfig.clientIdScheme.clientId)
+            assertEquals(jwtSecuredAuthorizationRequest.clientId, verifierConfig.verifierId.clientId)
             assertNotNull(jwtSecuredAuthorizationRequest.request)
             val presentation = loadPresentationById(testTransactionId)
             val requestObjectRetrieved = assertIs<Presentation.RequestObjectRetrieved>(presentation)
@@ -177,7 +177,7 @@ class InitTransactionTest {
             // we expect the Authorization Request to contain a request_uri
             // and the Presentation to be in state Requested
             val jwtSecuredAuthorizationRequest = useCase(input).getOrElse { fail("Unexpected $it") }
-            assertEquals(jwtSecuredAuthorizationRequest.clientId, verifierConfig.clientIdScheme.clientId)
+            assertEquals(jwtSecuredAuthorizationRequest.clientId, verifierConfig.verifierId.clientId)
             assertNull(jwtSecuredAuthorizationRequest.request)
             assertNotNull(jwtSecuredAuthorizationRequest.requestUri)
             val presentation = loadPresentationById(testTransactionId)
@@ -204,7 +204,7 @@ class InitTransactionTest {
             // we expect the Authorization Request to contain a request that contains a presentation_definition_uri
             // and the Presentation to be in state RequestedObjectRetrieved
             val jwtSecuredAuthorizationRequest = useCase(input).getOrElse { fail("Unexpected $it") }
-            assertEquals(jwtSecuredAuthorizationRequest.clientId, verifierConfig.clientIdScheme.clientId)
+            assertEquals(jwtSecuredAuthorizationRequest.clientId, verifierConfig.verifierId.clientId)
             assertNotNull(jwtSecuredAuthorizationRequest.request)
             val claims = SignedJWT.parse(jwtSecuredAuthorizationRequest.request).payload!!.toJSONObject()!!
             assertEquals(uri.toExternalForm(), claims["presentation_definition_uri"])


### PR DESCRIPTION
Closes #216 

Merging this also affects [eu-digital-identity-wallet/eudi-web-verifier](https://github.com/eu-digital-identity-wallet/eudi-web-verifier) and required eu-digital-identity-wallet/eudi-web-verifier#98 to be merged.

~~Additionally note that this PR bumps the version to `0.3.0-SNAPSHOT`.~~