### PR TITLE
Set `client_id` as the expected `aud` of KeyBinding JWT

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -155,7 +155,7 @@ internal fun beans(clock: Clock) = beans {
     bean { GetJarmJwksLive(ref(), clock, ref()) }
     bean { GetPresentationEventsLive(ref(), ref()) }
     bean { ValidateMsoMdocDeviceResponse(clock, trustedIssuers) }
-    bean { ValidateSdJwtVc(trustedIssuers, env.publicUrl()) }
+    bean { ValidateSdJwtVc(trustedIssuers, ref<VerifierConfig>().clientIdScheme.clientId) }
 
     //
     // Scheduled


### PR DESCRIPTION
Closes #229 