### PR TITLE
Update default JAR signing algorithm to ES256

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,12 +511,12 @@ Description: Algorithm used to sign Authorization Request
 Possible values: Any `Algorithm Name` of an IANA registered asymmetric signature algorithm (i.e. Usage is `alg`):
 https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms   
 Note: The configured signing algorithm must be compatible with the configured signing key  
-Default value: `RS256`
+Default value: `ES256`
 
 Variable: `VERIFIER_JAR_SIGNING_KEY`  
 Description: Key to use for Authorization Request signing  
 Possible values: `GenerateRandom`, `LoadFromKeystore`  
-Setting this value to `GenerateRandom` will result in the generation of a random `RSA` key   
+Setting this value to `GenerateRandom` will result in the generation of a random `EC` key using the curve `P-256`   
 Note: The configured signing key must be compatible with the configured signing algorithm  
 Default value: `GenerateRandom`
 

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -23,7 +23,7 @@ import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEAlgorithm
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.*
-import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jose.util.Base64
 import eu.europa.ec.eudi.verifier.endpoint.EmbedOptionEnum.ByReference
 import eu.europa.ec.eudi.verifier.endpoint.EmbedOptionEnum.ByValue
@@ -299,8 +299,8 @@ private fun jarSigningConfig(environment: Environment, clock: Clock): SigningCon
             }
         }
 
-        fun generateRandom(): RSAKey =
-            RSAKeyGenerator(4096, false)
+        fun generateRandom(): ECKey =
+            ECKeyGenerator(Curve.P_256)
                 .keyUse(KeyUse.SIGNATURE) // indicate the intended use of the key (optional)
                 .keyID(UUID.randomUUID().toString()) // give the key a unique ID (optional)
                 .issueTime(Date.from(clock.instant())) // issued-at timestamp (optional)
@@ -312,7 +312,7 @@ private fun jarSigningConfig(environment: Environment, clock: Clock): SigningCon
         }
     }
 
-    val algorithm = environment.getProperty("verifier.jar.signing.algorithm", "RS256").let(JWSAlgorithm::parse)
+    val algorithm = environment.getProperty("verifier.jar.signing.algorithm", "ES256").let(JWSAlgorithm::parse)
 
     return SigningConfig(key, algorithm)
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,7 +13,7 @@ spring.webflux.webjars-path-pattern=/webjars/**
 #
 verifier.originalClientId=Verifier
 verifier.clientIdScheme=pre-registered
-verifier.jar.signing.algorithm=RS256
+verifier.jar.signing.algorithm=ES256
 verifier.jar.signing.key=GenerateRandom
 #verifier.jar.signing.key=LoadFromKeystore
 #verifier.jar.signing.key.keystore=


### PR DESCRIPTION
Update default JAR signing configuration:

1. Randomly generated key is `ECKey` using Curve `P-256`
2. Signing algorithm is `ES256`

Closes #238 