### PR TITLE
Add default values to the constructor WalletMetadataTO.

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/RetrieveRequestObject.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/RetrieveRequestObject.kt
@@ -286,36 +286,36 @@ private class WalletMetadataValidator(private val verifierConfig: VerifierConfig
 @Serializable
 private data class WalletMetadataTO(
     @SerialName(OpenId4VPSpec.PRESENTATION_DEFINITION_URI_SUPPORTED)
-    val presentationDefinitionUriSupported: Boolean?,
+    val presentationDefinitionUriSupported: Boolean? = true,
 
     @Required
     @SerialName(OpenId4VPSpec.VP_FORMATS_SUPPORTED)
     val vpFormatsSupported: JsonObject,
 
     @SerialName(OpenId4VPSpec.CLIENT_ID_SCHEMES_SUPPORTED)
-    val clientIdSchemesSupported: List<String>?,
+    val clientIdSchemesSupported: List<String>? = listOf(OpenId4VPSpec.CLIENT_ID_SCHEME_PRE_REGISTERED),
 
     @SerialName(RFC8414.JWKS)
-    val jwks: JsonObject?,
+    val jwks: JsonObject? = null,
 
     @SerialName(RFC8414.JWKS_URI)
-    val jwksUri: String?,
+    val jwksUri: String? = null,
 
     @SerialName(JarmSpec.AUTHORIZATION_ENCRYPTION_ALGORITHMS_SUPPORTED)
-    val encryptionAlgorithmsSupported: List<String>?,
+    val encryptionAlgorithmsSupported: List<String>? = null,
 
     @SerialName(JarmSpec.AUTHORIZATION_ENCRYPTION_METHODS_SUPPORTED)
-    val encryptionMethodsSupported: List<String>?,
+    val encryptionMethodsSupported: List<String>? = null,
 
     @SerialName(RFC9101.REQUEST_OBJECT_SIGNING_ALGORITHMS_SUPPORTED)
-    val signingAlgorithmsSupported: List<String>?,
+    val signingAlgorithmsSupported: List<String>? = null,
 
     @Required
     @SerialName(RFC8414.RESPONSE_TYPES_SUPPORTED)
     val responseTypesSupported: List<String>,
 
     @SerialName(RFC8414.RESPONSE_MODES_SUPPORTED)
-    val responseModesSupported: List<String>?,
+    val responseModesSupported: List<String>? = listOf(RFC8414.RESPONSE_MODE_QUERY, RFC8414.RESPONSE_MODE_FRAGMENT),
 )
 
 private fun parseWalletMetadata(serialized: String): Either<RetrieveRequestObjectError.UnparsableWalletMetadata, WalletMetadataTO> =


### PR DESCRIPTION
Ensures deserialization of `WalletMetadataTO` doesn't fail when optional properties are omitted.