### PR TITLE
Correctly parse spring boot env variables with array keys

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -526,7 +526,7 @@ private fun Environment.trustSources(): Map<Regex, TrustSourceConfig>? {
         // Parse LOTL configuration if present
         val lotlSourceConfig = getPropertyOrEnvVariable("$indexPrefix.lotl.location")?.takeIf { it.isNotBlank() }?.let { lotlLocation ->
             val location = URI(lotlLocation).toURL()
-            val serviceTypeFilter = getPropertyOrEnvVariable("$indexPrefix.lotl.serviceTypeFilter", ProviderKind::class.java)
+            val serviceTypeFilter = getPropertyOrEnvVariable<ProviderKind>("$indexPrefix.lotl.serviceTypeFilter")
             val refreshInterval = getPropertyOrEnvVariable("$indexPrefix.lotl.refreshInterval", "0 0 * * * *")
 
             val lotlKeystoreConfig = parseKeyStoreConfig("$indexPrefix.lotl.keystore")
@@ -555,8 +555,8 @@ private fun Environment.getPropertyOrEnvVariable(property: String, defaultValue:
     return getProperty(property) ?: getProperty(toEnvironmentVariable(property)) ?: defaultValue
 }
 
-private fun <T> Environment.getPropertyOrEnvVariable(property: String, targetType: Class<T>): T? {
-    return getProperty(property, targetType) ?: getProperty(toEnvironmentVariable(property), targetType)
+private inline fun <reified T> Environment.getPropertyOrEnvVariable(property: String): T? {
+    return getProperty(property, T::class.java) ?: getProperty(toEnvironmentVariable(property), T::class.java)
 }
 
 private fun toEnvironmentVariable(property: String): String {

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -563,6 +563,7 @@ private fun toEnvironmentVariable(property: String): String {
     return property.replace(".", "_")
         .replace("[", "_")
         .replace("]", "")
+        .replace("-", "")
         .uppercase()
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,28 +57,10 @@ cors.credentials=false
 cors.maxAge=3600
 
 # Trust Sources
-verifier.trustSources[0].pattern=.*
-verifier.trustSources[0].keystore.path=classpath:trusted-issuers.jks
-verifier.trustSources[0].keystore.type=JKS
-verifier.trustSources[0].keystore.password=
-
-## QEAA providers
-#verifier.trustSources[1].pattern=org.iso.18013.5.1.mDL.*
-#verifier.trustSources[1].lotl.location=https://ec.europa.eu/tools/lotl/eu-lotl.xml
-#verifier.trustSources[1].lotl.serviceTypeFilter=http://uri.etsi.org/TrstSvc/Svctype/EAA/Q
-#verifier.trustSources[1].lotl.refreshInterval=0 20 * * * *
-#verifier.trustSources[1].keystore.path=classpath:trusted-qeaa-providers.jks
-#verifier.trustSources[1].keystore.type=JKS
-#verifier.trustSources[1].keystore.password=
-
-## PuB-EEA providers
-#verifier.trustSources[2].pattern=eu.europa.ec.eudi.pseudonym.age_over_18.1.*
-#verifier.trustSources[2].lotl.location=https://ec.europa.eu/tools/lotl/eu-lotl.xml
-#verifier.trustSources[2].lotl.serviceTypeFilter=http://uri.etsi.org/TrstSvc/Svctype/EAA/Pub-EAA
-#verifier.trustSources[2].lotl.refreshInterval=0 40 * * * *
-#verifier.trustSources[2].keystore.path=classpath:trusted-pubeaa-providers.jks
-#verifier.trustSources[2].keystore.type=JKS
-#verifier.trustSources[2].keystore.password=
+#verifier.trustSources[0].pattern=.*
+#verifier.trustSources[0].keystore.path=classpath:lotl.jks
+#verifier.trustSources[0].keystore.type=JKS
+#verifier.trustSources[0].keystore.password=
 
 # Proxy settings
 #verifier.http.proxy.url=http://exmaple.com


### PR DESCRIPTION
Properties with array keys will now be properly parsed, either with the notation `verifier.trustSources[0].pattern` in application.properties, or with the notation `VERIFIER_TRUSTSOURCES_0_PATTERN` as environmental variables.