### PR TITLE
Introduce ResponseMode sealed hierarchy

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/GenerateEphemeralEncryptionKeyPairNimbus.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/GenerateEphemeralEncryptionKeyPairNimbus.kt
@@ -22,7 +22,6 @@ import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
-import eu.europa.ec.eudi.verifier.endpoint.domain.EphemeralEncryptionKeyPairJWK
 import eu.europa.ec.eudi.verifier.endpoint.domain.ResponseEncryptionOption
 import eu.europa.ec.eudi.verifier.endpoint.port.out.jose.GenerateEphemeralEncryptionKeyPair
 import java.util.*
@@ -34,9 +33,9 @@ class GenerateEphemeralEncryptionKeyPairNimbus(
     private val responseEncryptionOption: ResponseEncryptionOption,
 ) : GenerateEphemeralEncryptionKeyPair {
 
-    override fun invoke(): Either<Throwable, EphemeralEncryptionKeyPairJWK> {
+    override fun invoke(): Either<Throwable, JWK> {
         val alg = responseEncryptionOption.algorithm
-        return createEphemeralEncryptionKey(alg).map { EphemeralEncryptionKeyPairJWK.from(keyPair = it) }
+        return createEphemeralEncryptionKey(alg)
     }
 
     private fun createEphemeralEncryptionKey(alg: JWEAlgorithm): Either<Throwable, ECKey> = Either.catch {
@@ -47,9 +46,3 @@ class GenerateEphemeralEncryptionKeyPairNimbus(
         ecKeyGenerator.generate()
     }
 }
-
-fun EphemeralEncryptionKeyPairJWK.Companion.from(keyPair: ECKey): EphemeralEncryptionKeyPairJWK {
-    return EphemeralEncryptionKeyPairJWK(keyPair.toJSONString())
-}
-
-fun EphemeralEncryptionKeyPairJWK.jwk(): JWK = JWK.parse(value)

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/RequestObject.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/RequestObject.kt
@@ -80,9 +80,9 @@ internal fun requestObjectFromDomain(
         nonce = presentation.nonce.value,
         state = presentation.requestId.value,
         responseMode = when (presentation.responseMode) {
-            ResponseModeOption.DirectPost -> "direct_post"
-            ResponseModeOption.DirectPostJwt -> "direct_post.jwt"
-        }, // or direct_post for direct submission
+            ResponseMode.DirectPost -> OpenId4VPSpec.RESPONSE_MODE_DIRECT_POST
+            is ResponseMode.DirectPostJwt -> OpenId4VPSpec.RESPONSE_MODE_DIRECT_POST_JWT
+        },
         responseUri = verifierConfig.responseUriBuilder(presentation.requestId),
         issuedAt = clock.instant(),
         transactionData = transactionData,

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/OpenId4VPSpec.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/OpenId4VPSpec.kt
@@ -33,8 +33,8 @@ object OpenId4VPSpec {
     const val REQUEST_URI_METHOD_GET: String = "get"
     const val REQUEST_URI_METHOD_POST: String = "post"
 
-    const val DIRECT_POST: String = "direct_post"
-    const val DIRECT_POST_JWT: String = "direct_post.jwt"
+    const val RESPONSE_MODE_DIRECT_POST: String = "direct_post"
+    const val RESPONSE_MODE_DIRECT_POST_JWT: String = "direct_post.jwt"
 
     const val VP_FORMATS: String = "vp_formats"
 

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/Presentation.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/Presentation.kt
@@ -145,11 +145,6 @@ sealed interface WalletResponse {
 }
 
 @JvmInline
-value class EphemeralEncryptionKeyPairJWK(val value: String) {
-    companion object
-}
-
-@JvmInline
 value class ResponseCode(val value: String)
 
 sealed interface GetWalletResponseMethod {
@@ -175,8 +170,7 @@ sealed interface Presentation {
         val requestId: RequestId,
         val requestUriMethod: RequestUriMethod,
         val nonce: Nonce,
-        val responseEncryptionEphemeralKey: EphemeralEncryptionKeyPairJWK?,
-        val responseMode: ResponseModeOption,
+        val responseMode: ResponseMode,
         val getWalletResponseMethod: GetWalletResponseMethod,
         val issuerChain: NonEmptyList<X509Certificate>?,
     ) : Presentation
@@ -194,8 +188,7 @@ sealed interface Presentation {
         val requestId: RequestId,
         val requestObjectRetrievedAt: Instant,
         val nonce: Nonce,
-        val ephemeralEcPrivateKey: EphemeralEncryptionKeyPairJWK?,
-        val responseMode: ResponseModeOption,
+        val responseMode: ResponseMode,
         val getWalletResponseMethod: GetWalletResponseMethod,
         val issuerChain: NonEmptyList<X509Certificate>?,
     ) : Presentation {
@@ -213,7 +206,6 @@ sealed interface Presentation {
                         requested.requestId,
                         at,
                         requested.nonce,
-                        requested.responseEncryptionEphemeralKey,
                         requested.responseMode,
                         requested.getWalletResponseMethod,
                         requested.issuerChain,

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/VerifierConfig.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/VerifierConfig.kt
@@ -63,6 +63,26 @@ enum class ResponseModeOption {
     DirectPost,
     DirectPostJwt,
 }
+
+sealed interface ResponseMode {
+
+    data object DirectPost : ResponseMode
+
+    data class DirectPostJwt(
+        val ephemeralResponseEncryptionKey: JWK,
+    ) : ResponseMode {
+        init {
+            require(ephemeralResponseEncryptionKey.isPrivate)
+        }
+    }
+}
+
+val ResponseMode.option: ResponseModeOption
+    get() = when (this) {
+        ResponseMode.DirectPost -> ResponseModeOption.DirectPost
+        is ResponseMode.DirectPostJwt -> ResponseModeOption.DirectPostJwt
+    }
+
 data class ResponseEncryptionOption(
     val algorithm: JWEAlgorithm,
     val encryptionMethod: EncryptionMethod,

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/RetrieveRequestObject.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/RetrieveRequestObject.kt
@@ -240,7 +240,7 @@ private class WalletMetadataValidator(private val verifierConfig: VerifierConfig
         metadata: WalletMetadataTO,
         presentation: Presentation.Requested,
     ) {
-        val responseMode = presentation.responseMode.name()
+        val responseMode = presentation.responseMode.option.name()
         val supportedResponseModes = metadata.responseModesSupported ?: RFC8414.DEFAULT_RESPONSE_MODES_SUPPORTED
         ensure(responseMode in supportedResponseModes) {
             RetrieveRequestObjectError.UnsupportedWalletMetadata("Wallet does not support Response Mode '$responseMode'")
@@ -341,8 +341,8 @@ private val PresentationType.responseType: String
 
 private fun ResponseModeOption.name(): String =
     when (this) {
-        ResponseModeOption.DirectPost -> OpenId4VPSpec.DIRECT_POST
-        ResponseModeOption.DirectPostJwt -> OpenId4VPSpec.DIRECT_POST_JWT
+        ResponseModeOption.DirectPost -> OpenId4VPSpec.RESPONSE_MODE_DIRECT_POST
+        ResponseModeOption.DirectPostJwt -> OpenId4VPSpec.RESPONSE_MODE_DIRECT_POST_JWT
     }
 
 private fun JsonObject.toVpFormats(): Either<Throwable, List<VpFormat>> =

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/out/jose/GenerateEphemeralEncryptionKeyPair.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/out/jose/GenerateEphemeralEncryptionKeyPair.kt
@@ -16,11 +16,11 @@
 package eu.europa.ec.eudi.verifier.endpoint.port.out.jose
 
 import arrow.core.Either
-import eu.europa.ec.eudi.verifier.endpoint.domain.EphemeralEncryptionKeyPairJWK
+import com.nimbusds.jose.jwk.JWK
 
 /**
  * An out port that generates ephemeral key
  */
 fun interface GenerateEphemeralEncryptionKeyPair {
-    operator fun invoke(): Either<Throwable, EphemeralEncryptionKeyPairJWK>
+    operator fun invoke(): Either<Throwable, JWK>
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/out/jose/VerifyEncryptedResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/out/jose/VerifyEncryptedResponse.kt
@@ -16,14 +16,14 @@
 package eu.europa.ec.eudi.verifier.endpoint.port.out.jose
 
 import arrow.core.Either
-import eu.europa.ec.eudi.verifier.endpoint.domain.EphemeralEncryptionKeyPairJWK
+import com.nimbusds.jose.jwk.JWK
 import eu.europa.ec.eudi.verifier.endpoint.domain.Jwt
 import eu.europa.ec.eudi.verifier.endpoint.domain.Nonce
 import eu.europa.ec.eudi.verifier.endpoint.port.input.AuthorisationResponseTO
 fun interface VerifyEncryptedResponse {
 
     operator fun invoke(
-        ephemeralEcPrivateKey: EphemeralEncryptionKeyPairJWK,
+        ephemeralResponseEncryptionKey: JWK,
         encryptedResponse: Jwt,
         apv: Nonce,
     ): Either<Throwable, AuthorisationResponseTO>

--- a/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransactionTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransactionTest.kt
@@ -165,7 +165,7 @@ class InitTransactionTest {
             assertNotNull(jwtSecuredAuthorizationRequest.request)
             val presentation = loadPresentationById(testTransactionId)
             val requestObjectRetrieved = assertIs<Presentation.RequestObjectRetrieved>(presentation)
-            assertEquals(ResponseModeOption.DirectPost, requestObjectRetrieved.responseMode)
+            assertEquals(ResponseModeOption.DirectPost, requestObjectRetrieved.responseMode.option)
         }
 
     /**


### PR DESCRIPTION
This PR improve the models around response mode.

More specifically `Presentation` now contains a `ResponseMode`, which is a sealed hierarchy, instead of a `ResponseModeOption` alongside an ephemeral encryption key.

The ephemeral encryption key, now is part of `ResponseMode.DirectPostJwt`.

Additionally the value class `EphemeralEncryptionKeyPair` is removed and replaced with `JWK`. This value class was initially introduced to avoid coupling the representation of a Json Web Key with `JWK` from Nimbus, but what ended up happening is that we constantly serialize/deserialize `JWK` to/from `EphemeralEncryptionKeyPair`. 