### PR TITLE
Make dependabot ignore specific dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
         patterns:
           - "*"
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "id.walt.mdoc-credentials:waltid-mdoc-credentials-jvm"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
In order for dependabot to be able to update all the other dependencies, 'id.walt.mdoc-credentials:waltid-mdoc-credentials-jvm' needs to be ignored.

In other libraries, dependencies are split in update `groups`.

Since we are not planning to update it it any further and lock it down ( or possibly remove it in the future) ignore seems more appropriate. 