### PR TITLE
Update SD-JWT library to 0.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,7 +744,11 @@ Default value: `not_used`
 
 Variable: `VERIFIER_VALIDATION_SDJWTVC_TYPEMETADATA_POLICY_REQUIREDFOR`  
 Description: Comma separated list of VCTs for which Type Metadata are required for. Required when `VERIFIER_VALIDATION_SDJWTVC_TYPEMETADATA_POLICY` is set to `required_for`  
-Example: `urn:eudi:pid:1`
+Example: `urn:eudi:pid:1` 
+
+Variable: `VERIFIER_VALIDATION_SDJWTVC_TYPEMETADATA_INTEGRITYCHECK_ENABLED`  
+Description: Enables integrity check validation for SD-JWT VC Type Metadata.  
+Default value: `false`
 
 #### SD-JWT-VC Type Metadata resolution
 

--- a/README.md
+++ b/README.md
@@ -748,7 +748,7 @@ Example: `urn:eudi:pid:1`
 
 Variable: `VERIFIER_VALIDATION_SDJWTVC_TYPEMETADATA_INTEGRITYCHECK_ENABLED`  
 Description: Enables integrity check validation for SD-JWT VC Type Metadata.  
-Default value: `false`
+Default value: `false` 
 
 #### SD-JWT-VC Type Metadata resolution
 

--- a/README.md
+++ b/README.md
@@ -744,11 +744,7 @@ Default value: `not_used`
 
 Variable: `VERIFIER_VALIDATION_SDJWTVC_TYPEMETADATA_POLICY_REQUIREDFOR`  
 Description: Comma separated list of VCTs for which Type Metadata are required for. Required when `VERIFIER_VALIDATION_SDJWTVC_TYPEMETADATA_POLICY` is set to `required_for`  
-Example: `urn:eudi:pid:1` 
-
-Variable: `VERIFIER_VALIDATION_SDJWTVC_TYPEMETADATA_INTEGRITYCHECK_ENABLED`  
-Description: Enables integrity check validation for SD-JWT VC Type Metadata.  
-Default value: `false` 
+Example: `urn:eudi:pid:1`  
 
 #### SD-JWT-VC Type Metadata resolution
 
@@ -770,6 +766,15 @@ Default value: `PT1H`
 Variable: `VERIFIER_VALIDATION_SDJWTVC_TYPEMETADATA_RESOLUTION_CACHE_MAXENTRIES`  
 Description: Cache maximum entries for resolved Type Metadata  
 Default value: `10`  
+
+Variable: `VERIFIER_VALIDATION_SDJWTVC_TYPEMETADATA_RESOLUTION_INTEGRITY_ENABLED`  
+Description: Enables sub-resource integrity validation for SD-JWT VC Type Metadata and JSON schemas  
+Default value: `false`
+
+Variable: `VERIFIER_VALIDATION_SDJWTVC_TYPEMETADATA_RESOLUTION_INTEGRITY_ALLOWEDALGORITHMS`    
+Description: Comma-separated list of allowed sub-resource integrity hash algorithms  
+Allowed values: `sha256`, `sha384`, `sha512`  
+Default value: `sha256,sha384,sha512`  
 
 Variable: `VERIFIER_VALIDATION_SDJWTVC_TYPEMETADATA_JSONSCHEMA_VALIDATION_ENABLED`  
 Description: Whether Json Schema validation should be enabled or not    

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,12 @@ dependencies {
     implementation(libs.ktor.client.apache) {
         because("ktor client engine to use (required by SdJwtVcVerifier)")
     }
+    implementation(libs.ktor.client.content.negotiation) {
+        because("ktor client content negotiation (required by http client for SD-JWT)")
+    }
+    implementation(libs.ktor.client.serialization) {
+        because("ktor client serialization (required by http client for SD-JWT)")
+    }
     implementation(libs.jsonpathkt) {
         because("Evaluate JsonPaths on vp_token")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ arrow = "2.0.1"
 dependencycheck = "12.1.1"
 swaggerUi = "5.20.1"
 waltid = "0.11.0"
-sdJwt = "0.14.3"
+sdJwt = "0.17.0"
 ktor = "3.2.3"
 jsonpathkt = "2.0.1"
 tink = "1.17.0"
@@ -37,6 +37,8 @@ swagger-ui = { module = "org.webjars:swagger-ui", version.ref = "swaggerUi" }
 waltid-mdoc-credentials = { module = "id.walt.mdoc-credentials:waltid-mdoc-credentials-jvm", version.ref = "waltid" }
 sd-jwt = { module = "eu.europa.ec.eudi:eudi-lib-jvm-sdjwt-kt", version.ref = "sdJwt" }
 ktor-client-apache = { module = "io.ktor:ktor-client-apache", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-serialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 jsonpathkt = { module = "com.nfeld.jsonpathkt:jsonpathkt", version.ref = "jsonpathkt" }
 tink = { module = "com.google.crypto.tink:tink", version.ref = "tink" }
 statium = { module = "eu.europa.ec.eudi:eudi-lib-kmp-statium", version.ref = "statium" }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -287,6 +287,7 @@ internal fun beans(clock: Clock) = beans {
                 LookupJsonSchemaUsingKtor(ref()),
             )
 
+            val enabledIntegrityCheck = env.getProperty<Boolean>("verifier.validation.sdJwtVc.typeMetadata.integrityCheck.enabled", false)
             return object : ResolveTypeMetadata by delegate {
                 override suspend fun invoke(
                     vct: Vct,
@@ -294,7 +295,10 @@ internal fun beans(clock: Clock) = beans {
                 ): Result<ResolvedTypeMetadata> =
                     runCatching {
                         cache.get(vct) {
-                            super.invoke(vct, null).getOrThrow()
+                            if (enabledIntegrityCheck)
+                                super.invoke(vct, expectedIntegrity).getOrThrow()
+                            else
+                                super.invoke(vct, null).getOrThrow()
                         }
                     }
             }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -196,12 +196,12 @@ internal fun beans(clock: Clock) = beans {
         log.info("Enabling Status List Token validations")
         bean<StatusListTokenValidator> {
             val selfSignedProfileActive = env.activeProfiles.contains("self-signed")
-            val httpClientFactory = if (selfSignedProfileActive) {
+            val httpClient = if (selfSignedProfileActive) {
                 createHttpClient(withJsonContentNegotiation = false, trustSelfSigned = true, httpProxy = proxy)
             } else {
                 createHttpClient(withJsonContentNegotiation = false, trustSelfSigned = false, httpProxy = proxy)
             }
-            StatusListTokenValidator(httpClientFactory, clock, ref())
+            StatusListTokenValidator(httpClient, clock, ref())
         }
     }
 
@@ -259,8 +259,8 @@ internal fun beans(clock: Clock) = beans {
     //
     bean<TypeMetadataPolicy> {
         fun resolveTypeMetadata(): ResolveTypeMetadata {
-            val vcts = ref<TypeMetadataResolutionProperties>()
-                .vcts
+            val typeMetadataResolutionProperties = ref<TypeMetadataResolutionProperties>()
+            val vcts = typeMetadataResolutionProperties.vcts
                 .associateBy { Vct(it.vct) }.mapValues { Url(it.value.url) }
             require(vcts.isNotEmpty()) {
                 "verifier.validation.sdJwtVc.typeMetadata.resolution.vcts must be set"
@@ -279,27 +279,28 @@ internal fun beans(clock: Clock) = beans {
                 .maximumSize(cacheSize)
                 .asCache<Vct, ResolvedTypeMetadata>()
 
+            val sriValidator =
+                if (!typeMetadataResolutionProperties.integrity.enabled) {
+                    null
+                } else {
+                    SRIValidator(
+                        requireNotNull(typeMetadataResolutionProperties.integrity.allowedAlgorithms.toNonEmptySetOrNull()) {
+                            "verifier.validation.sdJwtVc.typeMetadata.resolution.integrity.allowedAlgorithms cannot be empty"
+                        },
+                    )
+                }
             val delegate = ResolveTypeMetadata(
-                LookupTypeMetadataFromUrl(
-                    ref(),
-                    vcts,
-                ),
-                LookupJsonSchemaUsingKtor(ref()),
+                LookupTypeMetadataFromUrl(ref(), vcts, sriValidator),
+                LookupJsonSchemaUsingKtor(ref(), sriValidator),
             )
 
-            val enabledIntegrityCheck = env.getProperty<Boolean>("verifier.validation.sdJwtVc.typeMetadata.integrityCheck.enabled", false)
             return object : ResolveTypeMetadata by delegate {
                 override suspend fun invoke(
                     vct: Vct,
                     expectedIntegrity: DocumentIntegrity?,
                 ): Result<ResolvedTypeMetadata> =
                     runCatching {
-                        cache.get(vct) {
-                            if (enabledIntegrityCheck)
-                                super.invoke(vct, expectedIntegrity).getOrThrow()
-                            else
-                                super.invoke(vct, null).getOrThrow()
-                        }
+                        cache.get(vct) { super.invoke(vct, expectedIntegrity).getOrThrow() }
                     }
             }
         }
@@ -829,9 +830,15 @@ private enum class TypeMetadataPolicyEnum {
 @ConfigurationProperties("verifier.validation.sd-jwt-vc.type-metadata.resolution")
 internal data class TypeMetadataResolutionProperties(
     val vcts: List<VctProperties> = emptyList(),
+    val integrity: IntegrityProperties = IntegrityProperties(),
 ) {
     data class VctProperties(
         val vct: String,
         val url: String,
+    )
+
+    data class IntegrityProperties(
+        val enabled: Boolean = false,
+        val allowedAlgorithms: Set<IntegrityAlgorithm> = IntegrityAlgorithm.entries.toSet(),
     )
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/sdjwtvc/LookupTypeMetadataFromUrl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/sdjwtvc/LookupTypeMetadataFromUrl.kt
@@ -16,24 +16,25 @@
 package eu.europa.ec.eudi.verifier.endpoint.adapter.out.sdjwtvc
 
 import arrow.core.Either
-import eu.europa.ec.eudi.sdjwt.vc.KtorHttpClientFactory
+import eu.europa.ec.eudi.sdjwt.vc.DocumentIntegrity
 import eu.europa.ec.eudi.sdjwt.vc.LookupTypeMetadata
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcTypeMetadata
 import eu.europa.ec.eudi.sdjwt.vc.Vct
 import eu.europa.ec.eudi.verifier.endpoint.adapter.out.utils.toResult
+import io.ktor.client.HttpClient
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 
 class LookupTypeMetadataFromUrl(
-    private val httpClientFactory: KtorHttpClientFactory,
+    private val httpClient: HttpClient,
     private val vcts: Map<Vct, Url>,
 ) : LookupTypeMetadata {
-    override suspend fun invoke(vct: Vct): Result<SdJwtVcTypeMetadata?> =
+    override suspend fun invoke(vct: Vct, expectedIntegrity: DocumentIntegrity?): Result<SdJwtVcTypeMetadata?> =
         Either.catch {
             vcts[vct]?.let { url ->
-                httpClientFactory().use { httpClient ->
+                httpClient.use { httpClient ->
                     val response = httpClient.get(url) {
                         expectSuccess = false
                     }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/sdjwtvc/StatusListTokenValidator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/sdjwtvc/StatusListTokenValidator.kt
@@ -18,7 +18,6 @@ package eu.europa.ec.eudi.verifier.endpoint.adapter.out.sdjwtvc
 import arrow.core.Either
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.sdjwt.SdJwtAndKbJwt
-import eu.europa.ec.eudi.sdjwt.vc.KtorHttpClientFactory
 import eu.europa.ec.eudi.statium.*
 import eu.europa.ec.eudi.verifier.endpoint.adapter.out.json.decodeAs
 import eu.europa.ec.eudi.verifier.endpoint.adapter.out.json.toJsonObject
@@ -26,6 +25,7 @@ import eu.europa.ec.eudi.verifier.endpoint.adapter.out.utils.getOrThrow
 import eu.europa.ec.eudi.verifier.endpoint.domain.TransactionId
 import eu.europa.ec.eudi.verifier.endpoint.port.out.persistence.PresentationEvent
 import eu.europa.ec.eudi.verifier.endpoint.port.out.persistence.PublishPresentationEvent
+import io.ktor.client.HttpClient
 import kotlinx.serialization.json.JsonObject
 import kotlin.time.Clock
 import kotlin.time.Instant
@@ -34,7 +34,7 @@ import kotlin.time.toKotlinInstant
 internal data class StatusCheckException(val reason: String, val causedBy: Throwable) : Exception(reason, causedBy)
 
 internal class StatusListTokenValidator(
-    private val httpClientFactory: KtorHttpClientFactory,
+    private val httpClient: HttpClient,
     private val clock: java.time.Clock,
     private val publishPresentationEvent: PublishPresentationEvent,
 ) {
@@ -60,7 +60,7 @@ internal class StatusListTokenValidator(
         }
         val getStatusListToken: GetStatusListToken = GetStatusListToken.usingJwt(
             clock = delegateClock,
-            httpClient = httpClientFactory(),
+            httpClient = httpClient,
             verifyStatusListTokenSignature = { _, _ ->
                 Result.success(Unit)
             },

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/RetrieveRequestObject.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/RetrieveRequestObject.kt
@@ -167,7 +167,7 @@ class RetrieveRequestObjectLive(
 /**
  * Validator for Wallet Metadata.
  */
-private class WalletMetadataValidator(private val verifierConfig: VerifierConfig, private val clientFactory: HttpClient) {
+private class WalletMetadataValidator(private val verifierConfig: VerifierConfig, private val httpClient: HttpClient) {
 
     suspend fun validate(
         metadata: WalletMetadataTO,
@@ -259,7 +259,7 @@ private class WalletMetadataValidator(private val verifierConfig: VerifierConfig
             )
         }
 
-        val jwks = metadata.jwks?.toJwks()?.bind() ?: metadata.jwksUri?.let { clientFactory.use { client -> client.getJwks(it).bind() } }
+        val jwks = metadata.jwks?.toJwks()?.bind() ?: metadata.jwksUri?.let { httpClient.getJwks(it).bind() }
         return if (null == jwks) {
             EncryptionRequirement.NotRequired
         } else {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,11 +67,12 @@ cors.maxAge=3600
 # SD-JWT VC Type Metadata policy
 verifier.validation.sdJwtVc.typeMetadata.policy=not-used
 #verifier.validation.sdJwtVc.typeMetadata.policy.requiredFor=urn:eudi:pid:1
-verifier.validation.sdJwtVc.typeMetadata.integrityCheck.enabled=false
 
 # SD-JWT VC Type Metadata resolution
 verifier.validation.sdJwtVc.typeMetadata.resolution.cache.ttl=PT1H
 verifier.validation.sdJwtVc.typeMetadata.resolution.cache.maxEntries=10
+verifier.validation.sdJwtVc.typeMetadata.resolution.integrity.enabled=false
+verifier.validation.sdJwtVc.typeMetadata.resolution.integrity.allowedAlgorithms=sha256,sha384,sha512
 #verifier.validation.sdJwtVc.typeMetadata.resolution.vcts[0].vct=urn:eudi:pid:1
 #verifier.validation.sdJwtVc.typeMetadata.resolution.vcts[0].url=https://dev.issuer-backend.eudiw.dev/type-metadata/urn:eudi:pid:1
 verifier.validation.sdJwtVc.typeMetadata.jsonSchema.validation.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,6 +67,7 @@ cors.maxAge=3600
 # SD-JWT VC Type Metadata policy
 verifier.validation.sdJwtVc.typeMetadata.policy=not-used
 #verifier.validation.sdJwtVc.typeMetadata.policy.requiredFor=urn:eudi:pid:1
+verifier.validation.sdJwtVc.typeMetadata.integrityCheck.enabled=false
 
 # SD-JWT VC Type Metadata resolution
 verifier.validation.sdJwtVc.typeMetadata.resolution.cache.ttl=PT1H


### PR DESCRIPTION
Also, add Ktor content negotiation/serialization dependencies and refactor HTTP client handling

~Currently `expectedIntegrity` is always null~
A new configuration has been added:
`VERIFIER_VALIDATION_SDJWTVC_TYPEMETADATA_INTEGRITYCHECK_ENABLED` 
which allows for integrity check to be disable on the fly.

Closes #433 