### PR TITLE
Don't include the "scope" parameter in the request if there are no scopes

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/CreateJarNimbus.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/CreateJarNimbus.kt
@@ -113,7 +113,7 @@ class CreateJarNimbus : CreateJar {
 
         val authorizationRequestClaims = with(AuthorizationRequest.Builder(responseType, clientId)) {
             state(state)
-            if(scope.isNotEmpty()) {
+            if (scope.isNotEmpty()) {
                 scope(scope)
             }
             responseMode(NimbusResponseMode(r.responseMode))


### PR DESCRIPTION
Fixes #445 