### PR TITLE
Introduce Utlity API to process an SD-JWT VC

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -244,6 +244,7 @@ internal fun beans(clock: Clock) = beans {
             ref(),
         )
     }
+    bean { ProcessSdJwtVc() }
 
     bean {
         ValidateSdJwtVcOrMsoMdocVerifiablePresentation(
@@ -379,7 +380,7 @@ internal fun beans(clock: Clock) = beans {
             webJarResourcesBasePath = env.getRequiredProperty("spring.webflux.webjars-path-pattern")
                 .removeSuffix("/**"),
         )
-        val utilityApi = UtilityApi(ref(), ref())
+        val utilityApi = UtilityApi(ref(), ref(), ref())
         walletApi.route
             .and(verifierApi.route)
             .and(staticContent.route)

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/UtilityApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/UtilityApi.kt
@@ -18,15 +18,20 @@ package eu.europa.ec.eudi.verifier.endpoint.adapter.input.web
 import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps
 import eu.europa.ec.eudi.verifier.endpoint.domain.Nonce
 import eu.europa.ec.eudi.verifier.endpoint.port.input.*
+import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.web.reactive.function.server.*
 import org.springframework.web.reactive.function.server.ServerResponse.badRequest
 import org.springframework.web.reactive.function.server.ServerResponse.ok
+import kotlin.collections.firstOrNull
+
+private val log = LoggerFactory.getLogger(UtilityApi::class.java)
 
 internal class UtilityApi(
     private val validateMsoMdocDeviceResponse: ValidateMsoMdocDeviceResponse,
     private val validateSdJwtVc: ValidateSdJwtVc,
+    private val processSdJwtVc: ProcessSdJwtVc,
 ) {
     val route: RouterFunction<ServerResponse> = coRouter {
         POST(
@@ -40,11 +45,14 @@ internal class UtilityApi(
             contentType(APPLICATION_FORM_URLENCODED) and accept(APPLICATION_JSON),
             ::handleValidateSdJwtVc,
         )
+
+        POST(
+            PROCESS_SD_JWT_VC_PATH,
+            contentType(APPLICATION_FORM_URLENCODED) and accept(APPLICATION_JSON),
+            ::handleProcessSdJwtVc,
+        )
     }
 
-    /**
-     * Handles a request to validate an MsoMdoc DeviceResponse.
-     */
     private suspend fun handleValidateMsoMdocDeviceResponse(request: ServerRequest): ServerResponse {
         val form = request.awaitFormData()
         val vpToken = form["device_response"]
@@ -65,9 +73,6 @@ internal class UtilityApi(
         }
     }
 
-    /**
-     * Handles a request to validate an SD-JWT Verifiable Credential.
-     */
     private suspend fun handleValidateSdJwtVc(request: ServerRequest): ServerResponse {
         val form = request.awaitFormData()
         val unverifiedSdJwtVc = form["sd_jwt_vc"]
@@ -94,8 +99,27 @@ internal class UtilityApi(
         }
     }
 
+    private suspend fun handleProcessSdJwtVc(request: ServerRequest): ServerResponse {
+        val form = request.awaitFormData()
+        val unprocessedSdJwtVc = form["sd_jwt_vc"]
+            ?.firstOrNull { it.isNotBlank() }
+            .let {
+                requireNotNull(it) { "sd_jwt_vc must be provided" }
+            }
+
+        return processSdJwtVc(unprocessedSdJwtVc)
+            .fold(
+                ifLeft = { error ->
+                    log.warn("Could not process SD-JWT VC payload.", error)
+                    badRequest().buildAndAwait()
+                },
+                ifRight = { ok().json().bodyValueAndAwait(it) },
+            )
+    }
+
     companion object {
         const val VALIDATE_MSO_MDOC_DEVICE_RESPONSE_PATH = "/utilities/validations/msoMdoc/deviceResponse"
         const val VALIDATE_SD_JWT_VC_PATH = "/utilities/validations/sdJwtVc"
+        const val PROCESS_SD_JWT_VC_PATH = "/utilities/process/sdJwtVc"
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/ProcessSdJwtVc.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/ProcessSdJwtVc.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.verifier.endpoint.port.input
+
+import arrow.core.Either
+import eu.europa.ec.eudi.sdjwt.DefaultSdJwtOps
+import eu.europa.ec.eudi.sdjwt.JwtAndClaims
+import eu.europa.ec.eudi.sdjwt.SdJwtSpec
+import eu.europa.ec.eudi.sdjwt.SdJwtVcVerifier
+import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
+import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerifier
+import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataPolicy
+import kotlinx.serialization.json.JsonObject
+
+class ProcessSdJwtVc {
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
+        IssuerVerificationMethod.usingCustom(DefaultSdJwtOps.NoSignatureValidation),
+        TypeMetadataPolicy.NotUsed,
+    )
+
+    suspend operator fun invoke(unprocessed: String): Either<Throwable, JsonObject> = Either.catch {
+        if (unprocessed.endsWith(SdJwtSpec.DISCLOSURE_SEPARATOR)) {
+            verifier.processWithoutKeyBinding(unprocessed)
+        } else {
+            verifier.processWithKeyBinding(unprocessed)
+        }
+    }
+
+    private suspend fun SdJwtVcVerifier<JwtAndClaims>.processWithoutKeyBinding(unprocessed: String): JsonObject {
+        val sdJwt = verify(unprocessed).getOrThrow()
+        val (processed, _) = with(DefaultSdJwtOps) {
+            sdJwt.recreateClaimsAndDisclosuresPerClaim()
+        }
+        return processed
+    }
+
+    private suspend fun SdJwtVcVerifier<JwtAndClaims>.processWithKeyBinding(unprocessed: String): JsonObject {
+        val (sdJwt, _) = verify(unprocessed, challenge = null).getOrThrow()
+        val (processed, _) = with(DefaultSdJwtOps) {
+            sdJwt.recreateClaimsAndDisclosuresPerClaim()
+        }
+        return processed
+    }
+}

--- a/src/main/resources/public/openapi.json
+++ b/src/main/resources/public/openapi.json
@@ -422,6 +422,64 @@
           }
         }
       }
+    },
+    "/utilities/process/sdJwtVc": {
+      "post": {
+        "tags": [
+          "utility api"
+        ],
+        "summary": "Processes the payload of an SD-JWT Verifiable Credential.",
+        "description": "Processes the payload of an SD-JWT Verifiable Credential.",
+        "operationId": "processSdJwtVc",
+        "requestBody": {
+          "description": "The SD-JWT VC to process.",
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "nullable": false,
+                "properties": {
+                  "sd_jwt_vc": {
+                    "type": "string",
+                    "nullable": false
+                  }
+                },
+                "required": [
+                  "sd_jwt_vc"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "The payload of the processed SD-JWT-VC including all disclosed claims.",
+                  "type": "object",
+                  "nullable": false,
+                  "additionalProperties": true
+                },
+                "examples": {
+                  "SdJwtVcPidProccessedPayload": {
+                    "$ref": "#/components/examples/SdJwtVcPidProccessedPayload"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
This PR introduces a new Utility API to process the payload of an SD-JWT VC.

The API:
1. Performs standard SD-JWT VC checks, e.g. ensure all the provided Disclosure correspond to a Digest
2. Does **NOT** validate the signature of the Issuer
3. Validates the signature of the KeyBinding JWT, if present, against the `cnf` claim
4. Returns the process payload of the SD-JWT VC

The API has been kept as simple as possible. i.e. in case of an error a simple 400/Bad Request response is returned, with no further details.

Closes #485 