### PR TITLE
Relax GetWalletResponseLive to not require ResponseCode

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/GetWalletResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/GetWalletResponse.kt
@@ -87,7 +87,10 @@ class GetWalletResponseLive(
             null -> NotFound
             is Presentation.Submitted ->
                 when (responseCode) {
-                    presentation.responseCode -> found(presentation)
+                    null,
+                    presentation.responseCode,
+                    -> found(presentation)
+
                     else -> responseCodeMismatch(presentation, responseCode)
                 }
 


### PR DESCRIPTION
This PR updates `GetWalletResponseLive` to validate `ResponseCode` matches to what `Presentation` contains, only when a `ResponseCode` has been provided by the caller.

In effect this will allow a caller application to poll Verifier Endpoint for a Wallet response even when `wallet_response_redirect_uri_template` has been set during `InitTransaction`.

Closes #475 