### PR TITLE
Add post_get as a third option to the Request URI method

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/UnresolvedAuthorizationRequestUri.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/UnresolvedAuthorizationRequestUri.kt
@@ -34,7 +34,7 @@ value class UnresolvedAuthorizationRequestUri private constructor(val value: Uri
             .apply {
                 val requestUriMethod = when (requestUriMethod) {
                     RequestUriMethod.Get -> OpenId4VPSpec.REQUEST_URI_METHOD_GET
-                    RequestUriMethod.Post -> OpenId4VPSpec.REQUEST_URI_METHOD_POST
+                    RequestUriMethod.Post, RequestUriMethod.PostOrGet -> OpenId4VPSpec.REQUEST_URI_METHOD_POST
                 }
                 appendQueryParameter(OpenId4VPSpec.REQUEST_URI_METHOD, requestUriMethod)
             }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/VerifierConfig.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/VerifierConfig.kt
@@ -62,6 +62,7 @@ sealed interface EmbedOption<in ID> {
 enum class RequestUriMethod {
     Get,
     Post,
+    PostOrGet,
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransaction.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransaction.kt
@@ -62,6 +62,9 @@ enum class RequestUriMethodTO {
 
     @SerialName(OpenId4VPSpec.REQUEST_URI_METHOD_POST)
     Post,
+
+    @SerialName("post_get")
+    PostOrGet,
 }
 
 /**
@@ -417,6 +420,7 @@ class InitTransactionLive(
         when (initTransaction.requestUriMethod) {
             RequestUriMethodTO.Get -> RequestUriMethod.Get
             RequestUriMethodTO.Post -> RequestUriMethod.Post
+            RequestUriMethodTO.PostOrGet -> RequestUriMethod.PostOrGet
             null -> verifierConfig.requestUriMethod
         }
 
@@ -520,6 +524,7 @@ private fun RequestUriMethod.toTO(): RequestUriMethodTO =
     when (this) {
         RequestUriMethod.Get -> RequestUriMethodTO.Get
         RequestUriMethod.Post -> RequestUriMethodTO.Post
+        RequestUriMethod.PostOrGet -> RequestUriMethodTO.PostOrGet
     }
 
 private fun <T : Any, U : T> Collection<T>.containsAny(first: U, vararg rest: U): Boolean = first in this || rest.any { it in this }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/RetrieveRequestObject.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/RetrieveRequestObject.kt
@@ -126,8 +126,19 @@ class RetrieveRequestObjectLive(
                 publishPresentationEvent(event)
             }
 
-            ensure(method is RetrieveRequestObjectMethod.Get || RequestUriMethod.Post == presentation.requestUriMethod) {
-                RetrieveRequestObjectError.InvalidRequestUriMethod(presentation.requestUriMethod)
+            when (method) {
+                is RetrieveRequestObjectMethod.Get -> ensure(
+                    presentation.requestUriMethod == RequestUriMethod.PostOrGet ||
+                        presentation.requestUriMethod == RequestUriMethod.Get,
+                ) {
+                    RetrieveRequestObjectError.InvalidRequestUriMethod(presentation.requestUriMethod)
+                }
+                is RetrieveRequestObjectMethod.Post -> ensure(
+                    presentation.requestUriMethod == RequestUriMethod.PostOrGet ||
+                        presentation.requestUriMethod == RequestUriMethod.Post,
+                ) {
+                    RetrieveRequestObjectError.InvalidRequestUriMethod(presentation.requestUriMethod)
+                }
             }
 
             val walletMetadata = method.walletMetadataOrNull?.let { parseWalletMetadata(it).bind() }

--- a/src/main/resources/public/openapi.json
+++ b/src/main/resources/public/openapi.json
@@ -509,7 +509,8 @@
         "nullable": false,
         "enum": [
           "get",
-          "post"
+          "post",
+          "post_get"
         ]
       },
       "UriTemplate": {


### PR DESCRIPTION
This option allows the customization of the verifier's behaviour during the retrieval of the authorization request.

- `get` only allows `GET` method
- `post` only allows `POST`
- `post_get` allows both `POST` and `GET`


Closes #494 