### PR TITLE
[PROPOSAL] ConfigurationProperties registered as beans with Kotlin Beans DSL (BeanRegistrarDsl) and avoid the proliferation of bean() calls

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -27,6 +27,8 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.*
 import eu.europa.ec.eudi.sdjwt.vc.*
 import eu.europa.ec.eudi.verifier.endpoint.EmbedOptionEnum.ByReference
 import eu.europa.ec.eudi.verifier.endpoint.EmbedOptionEnum.ByValue
+import eu.europa.ec.eudi.verifier.endpoint.adapter.SpringExtensions.nullableBean
+import eu.europa.ec.eudi.verifier.endpoint.adapter.SpringExtensions.registerConfigurationPropertiesBean
 import eu.europa.ec.eudi.verifier.endpoint.adapter.input.timer.ScheduleDeleteOldPresentations
 import eu.europa.ec.eudi.verifier.endpoint.adapter.input.timer.ScheduleTimeoutPresentations
 import eu.europa.ec.eudi.verifier.endpoint.adapter.input.web.*
@@ -134,23 +136,17 @@ internal class AppBeans : BeanRegistrarDsl({
     //
     // Ktor
     //
-
-    val proxy = env.getProperty("verifier.http.proxy.url")?.let {
-        val url = Url(it)
-        val username = env.getProperty("verifier.http.proxy.username")
-        val password = env.getProperty("verifier.http.proxy.password")
-        HttpProxy(url, username, password)
-    }
+    registerConfigurationPropertiesBean<HttpProxy>("verifier.http.proxy")
 
     profile("self-signed") {
         log.warn("Using Ktor HttpClients that trust self-signed certificates and perform no hostname verification with proxy")
         registerBean<HttpClient> {
-            createHttpClient(trustSelfSigned = true, httpProxy = proxy)
+            createHttpClient(trustSelfSigned = true, httpProxy = nullableBean<HttpProxy, HttpClient>())
         }
     }
     profile("!self-signed") {
         registerBean<HttpClient> {
-            createHttpClient(httpProxy = proxy)
+            createHttpClient(httpProxy = nullableBean<HttpProxy, HttpClient>())
         }
     }
 
@@ -206,9 +202,17 @@ internal class AppBeans : BeanRegistrarDsl({
         registerBean<StatusListTokenValidator> {
             val selfSignedProfileActive = env.activeProfiles.contains("self-signed")
             val httpClient = if (selfSignedProfileActive) {
-                createHttpClient(withJsonContentNegotiation = false, trustSelfSigned = true, httpProxy = proxy)
+                createHttpClient(
+                    withJsonContentNegotiation = false,
+                    trustSelfSigned = true,
+                    httpProxy = nullableBean<HttpProxy, StatusListTokenValidator>(),
+                )
             } else {
-                createHttpClient(withJsonContentNegotiation = false, trustSelfSigned = false, httpProxy = proxy)
+                createHttpClient(
+                    withJsonContentNegotiation = false,
+                    trustSelfSigned = false,
+                    httpProxy = nullableBean<HttpProxy, StatusListTokenValidator>(),
+                )
             }
             StatusListTokenValidator(httpClient, bean(), bean())
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -27,7 +27,6 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.*
 import eu.europa.ec.eudi.sdjwt.vc.*
 import eu.europa.ec.eudi.verifier.endpoint.EmbedOptionEnum.ByReference
 import eu.europa.ec.eudi.verifier.endpoint.EmbedOptionEnum.ByValue
-import eu.europa.ec.eudi.verifier.endpoint.adapter.SpringExtensions.nullableBean
 import eu.europa.ec.eudi.verifier.endpoint.adapter.SpringExtensions.registerConfigurationPropertiesBean
 import eu.europa.ec.eudi.verifier.endpoint.adapter.input.timer.ScheduleDeleteOldPresentations
 import eu.europa.ec.eudi.verifier.endpoint.adapter.input.timer.ScheduleTimeoutPresentations
@@ -142,12 +141,12 @@ internal class AppBeans : BeanRegistrarDsl({
     profile("self-signed") {
         log.warn("Using Ktor HttpClients that trust self-signed certificates and perform no hostname verification with proxy")
         registerBean<HttpClient> {
-            createHttpClient(trustSelfSigned = true, httpProxy = nullableBean<HttpProxy, HttpClient>())
+            createHttpClient(trustSelfSigned = true, httpProxy = beanProvider<HttpProxy>().ifAvailable)
         }
     }
     profile("!self-signed") {
         registerBean<HttpClient> {
-            createHttpClient(httpProxy = nullableBean<HttpProxy, HttpClient>())
+            createHttpClient(httpProxy = beanProvider<HttpProxy>().ifAvailable)
         }
     }
 
@@ -206,13 +205,13 @@ internal class AppBeans : BeanRegistrarDsl({
                 createHttpClient(
                     withJsonContentNegotiation = false,
                     trustSelfSigned = true,
-                    httpProxy = nullableBean<HttpProxy, StatusListTokenValidator>(),
+                    httpProxy = beanProvider<HttpProxy>().ifAvailable,
                 )
             } else {
                 createHttpClient(
                     withJsonContentNegotiation = false,
                     trustSelfSigned = false,
-                    httpProxy = nullableBean<HttpProxy, StatusListTokenValidator>(),
+                    httpProxy = beanProvider<HttpProxy>().ifAvailable,
                 )
             }
             StatusListTokenValidator(httpClient, bean(), bean())

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -34,6 +34,7 @@ import eu.europa.ec.eudi.verifier.endpoint.adapter.input.timer.ScheduleTimeoutPr
 import eu.europa.ec.eudi.verifier.endpoint.adapter.input.web.*
 import eu.europa.ec.eudi.verifier.endpoint.adapter.out.cfg.GenerateRequestIdNimbus
 import eu.europa.ec.eudi.verifier.endpoint.adapter.out.cfg.GenerateTransactionIdNimbus
+import eu.europa.ec.eudi.verifier.endpoint.adapter.out.config.StringToAttestationsClassificationsConverter
 import eu.europa.ec.eudi.verifier.endpoint.adapter.out.consultation.Ignored
 import eu.europa.ec.eudi.verifier.endpoint.adapter.out.consultation.usingTrustAnchors
 import eu.europa.ec.eudi.verifier.endpoint.adapter.out.consultation.usingTrustValidatorService
@@ -76,6 +77,7 @@ import org.springframework.beans.factory.BeanRegistrarDsl
 import org.springframework.beans.factory.BeanRegistrarDsl.SupplierContextDsl
 import org.springframework.boot.context.properties.bind.Name
 import org.springframework.boot.http.codec.CodecCustomizer
+import org.springframework.core.convert.converter.Converter
 import org.springframework.core.env.Environment
 import org.springframework.core.env.getProperty
 import org.springframework.http.codec.json.KotlinSerializationJsonDecoder
@@ -219,7 +221,9 @@ internal class AppBeans : BeanRegistrarDsl({
 
     // Default IsChainTrustedForContextF
     registerConfigurationPropertiesBean<VerifierEndpointConfigurationProperties>("verifier")
-
+    registerBean<Converter<String, AttestationClassifications>> {
+        StringToAttestationsClassificationsConverter()
+    }
     registerBean {
         val config = bean<VerifierEndpointConfigurationProperties>()
         log.info("Using Attestation Classifications: ${config.attestationClassifications}")

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -348,7 +348,7 @@ internal class AppBeans : BeanRegistrarDsl({
     registerBean<VerifierApi>()
     registerBean<UtilityApi>()
     registerBean<StaticContent>()
-    registerBean<SwaggerUi>()
+    registerBean<SwaggerUi> { SwaggerUi(env) }
     registerBean {
         bean<WalletApi>().route
             .and(bean<VerifierApi>().route)

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -174,7 +174,7 @@ internal class AppBeans : BeanRegistrarDsl({
         )
     }
 
-    registerBean { RetrieveRequestObjectLive(bean(), bean(), bean(), bean(), bean(), bean(), bean()) }
+    registerBean<RetrieveRequestObjectLive>()
 
     registerBean {
         TimeoutPresentationsLive(
@@ -193,10 +193,10 @@ internal class AppBeans : BeanRegistrarDsl({
     }
 
     registerBean { GenerateResponseCode.Random }
-    registerBean { PostWalletResponseLive(bean(), bean(), bean(), bean(), bean(), bean(), bean(), bean(), bean()) }
+    registerBean<PostWalletResponseLive>()
     registerBean { GenerateEphemeralEncryptionKeyPairNimbus(bean<VerifierConfig>().clientMetaData.responseEncryptionOption) }
-    registerBean { GetWalletResponseLive(bean(), bean(), bean()) }
-    registerBean { GetPresentationEventsLive(bean(), bean()) }
+    registerBean<GetWalletResponseLive>()
+    registerBean<GetPresentationEventsLive>()
 
     if (env.getProperty("verifier.validation.sdJwtVc.statusCheck.enabled", true)) {
         log.info("Enabling Status List Token validations")
@@ -359,8 +359,8 @@ internal class AppBeans : BeanRegistrarDsl({
     //
     // Scheduled
     //
-    registerBean { ScheduleTimeoutPresentations(bean()) }
-    registerBean { ScheduleDeleteOldPresentations(bean()) }
+    registerBean<ScheduleTimeoutPresentations>()
+    registerBean<ScheduleDeleteOldPresentations>()
 
     //
     // Config

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -106,7 +106,7 @@ internal class AppBeans : BeanRegistrarDsl({
     // JOSE
     //
     registerBean { CreateJarNimbus() }
-    registerBean { VerifyEncryptedResponseWithNimbus(bean<VerifierConfig>().clientMetaData.responseEncryptionOption) }
+    registerBean<VerifyEncryptedResponseWithNimbus>()
 
     //
     // Persistence
@@ -172,25 +172,14 @@ internal class AppBeans : BeanRegistrarDsl({
             bean(),
         )
     }
-
     registerBean<RetrieveRequestObjectLive>()
-
-    registerBean {
-        TimeoutPresentationsLive(
-            bean(),
-            bean(),
-            bean<VerifierConfig>().maxAge,
-            bean(),
-            bean(),
-        )
-    }
+    registerBean<TimeoutPresentationsLive>()
     registerBean {
         val maxAge = Duration.parse(env.getProperty("verifier.presentations.cleanup.maxAge", "P10D"))
         require(maxAge.isPositive()) { "'verifier.presentations.cleanup.maxAge' cannot be zero or negative" }
 
         DeleteOldPresentationsLive(bean(), maxAge, bean())
     }
-
     registerBean { GenerateResponseCode.Random }
     registerBean<PostWalletResponseLive>()
     registerBean { GenerateEphemeralEncryptionKeyPairNimbus(bean<VerifierConfig>().clientMetaData.responseEncryptionOption) }
@@ -369,35 +358,17 @@ internal class AppBeans : BeanRegistrarDsl({
     //
     // End points
     //
-
+    registerBean<WalletApi>()
+    registerBean<VerifierApi>()
+    registerBean<UtilityApi>()
+    registerBean<StaticContent>()
+    registerBean<SwaggerUi>()
     registerBean {
-        val walletApi = WalletApi(
-            bean(),
-            bean(),
-            bean<VerifierConfig>().verifierId.accessCertificate.key,
-        )
-        val verifierApi = VerifierApi(
-            bean(),
-            bean(),
-            bean(),
-        )
-        val staticContent = StaticContent()
-        val swaggerUi = SwaggerUi(
-            publicResourcesBasePath = env.getRequiredProperty("spring.webflux.static-path-pattern").removeSuffix("/**"),
-            webJarResourcesBasePath = env.getRequiredProperty("spring.webflux.webjars-path-pattern")
-                .removeSuffix("/**"),
-        )
-        val utilityApi = UtilityApi(
-            bean(),
-            bean(),
-            bean(),
-            bean<VerifierEndpointConfigurationProperties>().attestationClassifications,
-        )
-        walletApi.route
-            .and(verifierApi.route)
-            .and(staticContent.route)
-            .and(swaggerUi.route)
-            .and(utilityApi.route)
+        bean<WalletApi>().route
+            .and(bean<VerifierApi>().route)
+            .and(bean<StaticContent>().route)
+            .and(bean<SwaggerUi>().route)
+            .and(bean<UtilityApi>().route)
     }
 
     //

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -74,7 +74,6 @@ import org.apache.http.ssl.SSLContextBuilder
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.BeanRegistrarDsl
 import org.springframework.beans.factory.BeanRegistrarDsl.SupplierContextDsl
-import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.Name
 import org.springframework.boot.http.codec.CodecCustomizer
 import org.springframework.core.env.Environment
@@ -219,6 +218,8 @@ internal class AppBeans : BeanRegistrarDsl({
     }
 
     // Default IsChainTrustedForContextF
+    registerConfigurationPropertiesBean<VerifierEndpointConfigurationProperties>("verifier")
+
     registerBean {
         val config = bean<VerifierEndpointConfigurationProperties>()
         log.info("Using Attestation Classifications: ${config.attestationClassifications}")
@@ -688,7 +689,6 @@ private enum class TypeMetadataPolicyEnum {
     RequiredFor,
 }
 
-@ConfigurationProperties("verifier")
 data class VerifierEndpointConfigurationProperties(
     val validation: ValidationConfigurationProperties,
     val trustValidator: TrustValidatorConfigurationProperties? = null,

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -156,22 +156,8 @@ internal class AppBeans : BeanRegistrarDsl({
     //
     // Use cases
     //
-    registerBean {
-        InitTransactionLive(
-            bean(),
-            bean(),
-            bean(),
-            bean(),
-            bean(),
-            bean(),
-            bean(),
-            WalletApi.requestJwtByReference(env.publicUrl()),
-            bean(),
-            bean(),
-            bean(),
-            bean(),
-        )
-    }
+    registerBean<EmbedOption.ByReference<RequestId>> { WalletApi.requestJwtByReference(env.publicUrl()) }
+    registerBean<InitTransactionLive>()
     registerBean<RetrieveRequestObjectLive>()
     registerBean<TimeoutPresentationsLive>()
     registerBean {

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -344,9 +344,13 @@ internal class AppBeans : BeanRegistrarDsl({
     //
     // End points
     //
-    registerBean<WalletApi>()
+    registerBean<WalletApi> {
+        WalletApi(bean(), bean(), bean<VerifierConfig>().verifierId.accessCertificate.key)
+    }
     registerBean<VerifierApi>()
-    registerBean<UtilityApi>()
+    registerBean<UtilityApi> {
+        UtilityApi(bean(), bean(), bean(), bean<VerifierEndpointConfigurationProperties>().attestationClassifications)
+    }
     registerBean<StaticContent>()
     registerBean<SwaggerUi> { SwaggerUi(env) }
     registerBean {

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierEndpointApplication.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierEndpointApplication.kt
@@ -16,13 +16,11 @@
 package eu.europa.ec.eudi.verifier.endpoint
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Import
 
 @SpringBootApplication
 @Import(AppBeans::class)
-@EnableConfigurationProperties(VerifierEndpointConfigurationProperties::class)
 class VerifierApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/SpringExtensions.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/SpringExtensions.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.verifier.endpoint.adapter
+
+import org.springframework.beans.factory.BeanRegistrarDsl
+import org.springframework.boot.context.properties.bind.BindException
+import org.springframework.boot.context.properties.bind.Binder
+
+object SpringExtensions {
+
+    inline fun <reified T : Any> BeanRegistrarDsl.registerConfigurationPropertiesBean(
+        property: String,
+        default: T? = null,
+    ): String? =
+        try {
+            Binder
+                .get(env)
+                .bind(property, T::class.java)
+                .orElse(default)
+        } catch (e: Exception) {
+            when {
+                e is BindException && e.name.toString() == property -> default
+                else -> throw e
+            }
+        }?.let {
+            registerBean { it }
+        }
+
+    inline fun <reified T : Any, reified R : Any> BeanRegistrarDsl.SupplierContextDsl<R>.nullableBean(): T? =
+        beanProvider<T>().ifAvailable
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/SpringExtensions.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/SpringExtensions.kt
@@ -38,7 +38,4 @@ object SpringExtensions {
         }?.let {
             registerBean { it }
         }
-
-    inline fun <reified T : Any, reified R : Any> BeanRegistrarDsl.SupplierContextDsl<R>.nullableBean(): T? =
-        beanProvider<T>().ifAvailable
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/SwaggerUi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/SwaggerUi.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.verifier.endpoint.adapter.input.web
 
 import eu.europa.ec.eudi.verifier.endpoint.domain.OpenId4VPSpec
 import org.slf4j.LoggerFactory
+import org.springframework.core.env.Environment
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.server.RouterFunction
@@ -34,9 +35,11 @@ private val log = LoggerFactory.getLogger(SwaggerUi::class.java)
  * @property route the routes handled by this web adapter
  */
 internal class SwaggerUi(
-    private val publicResourcesBasePath: String,
-    private val webJarResourcesBasePath: String,
+    env: Environment,
 ) {
+    private val publicResourcesBasePath: String = env.getRequiredProperty("spring.webflux.static-path-pattern").removeSuffix("/**")
+    private val webJarResourcesBasePath: String = env.getRequiredProperty("spring.webflux.webjars-path-pattern").removeSuffix("/**")
+
     val route: RouterFunction<ServerResponse> = coRouter {
         (GET("") or GET("/")) {
             log.info("Redirecting to {}", SWAGGER_UI)

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/SwaggerUi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/SwaggerUi.kt
@@ -24,6 +24,7 @@ import org.springframework.web.reactive.function.server.RouterFunction
 import org.springframework.web.reactive.function.server.ServerResponse
 import org.springframework.web.reactive.function.server.coRouter
 import org.springframework.web.reactive.function.server.renderAndAwait
+import kotlin.String
 
 private val log = LoggerFactory.getLogger(SwaggerUi::class.java)
 
@@ -35,11 +36,9 @@ private val log = LoggerFactory.getLogger(SwaggerUi::class.java)
  * @property route the routes handled by this web adapter
  */
 internal class SwaggerUi(
-    env: Environment,
+    private val publicResourcesBasePath: String,
+    private val webJarResourcesBasePath: String,
 ) {
-    private val publicResourcesBasePath: String = env.getRequiredProperty("spring.webflux.static-path-pattern").removeSuffix("/**")
-    private val webJarResourcesBasePath: String = env.getRequiredProperty("spring.webflux.webjars-path-pattern").removeSuffix("/**")
-
     val route: RouterFunction<ServerResponse> = coRouter {
         (GET("") or GET("/")) {
             log.info("Redirecting to {}", SWAGGER_UI)
@@ -66,3 +65,8 @@ internal class SwaggerUi(
         const val SWAGGER_UI = "/swagger-ui"
     }
 }
+
+internal operator fun SwaggerUi.Companion.invoke(env: Environment) = SwaggerUi(
+    publicResourcesBasePath = env.getRequiredProperty("spring.webflux.static-path-pattern").removeSuffix("/**"),
+    webJarResourcesBasePath = env.getRequiredProperty("spring.webflux.webjars-path-pattern").removeSuffix("/**"),
+)

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/UtilityApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/UtilityApi.kt
@@ -16,7 +16,6 @@
 package eu.europa.ec.eudi.verifier.endpoint.adapter.input.web
 
 import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps
-import eu.europa.ec.eudi.verifier.endpoint.VerifierEndpointConfigurationProperties
 import eu.europa.ec.eudi.verifier.endpoint.domain.AttestationClassifications
 import eu.europa.ec.eudi.verifier.endpoint.domain.Nonce
 import eu.europa.ec.eudi.verifier.endpoint.port.input.*
@@ -33,9 +32,8 @@ internal class UtilityApi(
     private val validateMsoMdocDeviceResponse: ValidateMsoMdocDeviceResponse,
     private val validateSdJwtVc: ValidateSdJwtVc,
     private val processSdJwtVc: ProcessSdJwtVc,
-    verifierEndpointConfigurationProperties: VerifierEndpointConfigurationProperties,
+    private val attestationClassifications: AttestationClassifications,
 ) {
-    private val attestationClassifications: AttestationClassifications = verifierEndpointConfigurationProperties.attestationClassifications
 
     val route: RouterFunction<ServerResponse> = coRouter {
         POST(

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/UtilityApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/UtilityApi.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.verifier.endpoint.adapter.input.web
 
 import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps
+import eu.europa.ec.eudi.verifier.endpoint.VerifierEndpointConfigurationProperties
 import eu.europa.ec.eudi.verifier.endpoint.domain.AttestationClassifications
 import eu.europa.ec.eudi.verifier.endpoint.domain.Nonce
 import eu.europa.ec.eudi.verifier.endpoint.port.input.*
@@ -32,8 +33,10 @@ internal class UtilityApi(
     private val validateMsoMdocDeviceResponse: ValidateMsoMdocDeviceResponse,
     private val validateSdJwtVc: ValidateSdJwtVc,
     private val processSdJwtVc: ProcessSdJwtVc,
-    private val attestationClassifications: AttestationClassifications,
+    verifierEndpointConfigurationProperties: VerifierEndpointConfigurationProperties,
 ) {
+    private val attestationClassifications: AttestationClassifications = verifierEndpointConfigurationProperties.attestationClassifications
+
     val route: RouterFunction<ServerResponse> = coRouter {
         POST(
             VALIDATE_MSO_MDOC_DEVICE_RESPONSE_PATH,

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/WalletApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/WalletApi.kt
@@ -42,12 +42,10 @@ private val REQUEST_OBJECT_MEDIA_TYPE = MediaType.parseMediaType(RFC9101.REQUEST
 class WalletApi(
     private val retrieveRequestObject: RetrieveRequestObject,
     private val postWalletResponse: PostWalletResponse,
-    verifierConfig: VerifierConfig,
+    private val signingKey: JWK,
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(WalletApi::class.java)
-
-    private val signingKey: JWK = verifierConfig.verifierId.accessCertificate.key
 
     /**
      * The routes available to the wallet

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/WalletApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/WalletApi.kt
@@ -42,10 +42,12 @@ private val REQUEST_OBJECT_MEDIA_TYPE = MediaType.parseMediaType(RFC9101.REQUEST
 class WalletApi(
     private val retrieveRequestObject: RetrieveRequestObject,
     private val postWalletResponse: PostWalletResponse,
-    private val signingKey: JWK,
+    verifierConfig: VerifierConfig,
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(WalletApi::class.java)
+
+    private val signingKey: JWK = verifierConfig.verifierId.accessCertificate.key
 
     /**
      * The routes available to the wallet

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/config/StringToAttestationsClassificationsConverter.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/config/StringToAttestationsClassificationsConverter.kt
@@ -17,12 +17,8 @@ package eu.europa.ec.eudi.verifier.endpoint.adapter.out.config
 
 import eu.europa.ec.eudi.verifier.endpoint.adapter.out.json.jsonSupport
 import eu.europa.ec.eudi.verifier.endpoint.domain.AttestationClassifications
-import org.springframework.boot.context.properties.ConfigurationPropertiesBinding
 import org.springframework.core.convert.converter.Converter
-import org.springframework.stereotype.Component
 
-@ConfigurationPropertiesBinding
-@Component
 class StringToAttestationsClassificationsConverter : Converter<String, AttestationClassifications> {
     override fun convert(source: String): AttestationClassifications =
         jsonSupport.decodeFromString(source)

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/VerifyEncryptedResponseWithNimbus.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/VerifyEncryptedResponseWithNimbus.kt
@@ -40,9 +40,9 @@ import org.slf4j.LoggerFactory
  * Decrypts an encrypted JWT and maps the JWT claimSet to an AuthorisationResponseTO
  */
 class VerifyEncryptedResponseWithNimbus(
-    private val responseEncryptionOption: ResponseEncryptionOption,
+    verifierConfig: VerifierConfig,
 ) : VerifyEncryptedResponse {
-
+    private val responseEncryptionOption: ResponseEncryptionOption = verifierConfig.clientMetaData.responseEncryptionOption
     private val logger: Logger = LoggerFactory.getLogger(VerifyEncryptedResponseWithNimbus::class.java)
 
     override fun invoke(

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/TimeoutPresentations.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/TimeoutPresentations.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.eudi.verifier.endpoint.port.input
 import eu.europa.ec.eudi.verifier.endpoint.domain.Clock
 import eu.europa.ec.eudi.verifier.endpoint.domain.Presentation
 import eu.europa.ec.eudi.verifier.endpoint.domain.TransactionId
+import eu.europa.ec.eudi.verifier.endpoint.domain.VerifierConfig
 import eu.europa.ec.eudi.verifier.endpoint.domain.timedOut
 import eu.europa.ec.eudi.verifier.endpoint.port.out.persistence.LoadIncompletePresentationsOlderThan
 import eu.europa.ec.eudi.verifier.endpoint.port.out.persistence.PresentationEvent
@@ -33,10 +34,12 @@ fun interface TimeoutPresentations {
 class TimeoutPresentationsLive(
     private val loadIncompletePresentationsOlderThan: LoadIncompletePresentationsOlderThan,
     private val storePresentation: StorePresentation,
-    private val maxAge: Duration,
+    verifierConfig: VerifierConfig,
     private val clock: Clock,
     private val publishPresentationEvent: PublishPresentationEvent,
 ) : TimeoutPresentations {
+    private val maxAge: Duration = verifierConfig.maxAge
+
     override suspend operator fun invoke(): List<TransactionId> {
         val expireBefore = clock.now() - maxAge
         return loadIncompletePresentationsOlderThan(expireBefore).mapNotNull { timeout(it)?.id }


### PR DESCRIPTION
1. This is about aligning the `ConfigurationProperties` with `BeanRegistrarDsl` and avoid spring annotations. 

The `BeanRegistrarDsl` (including nested ones) must include (if possible) the registration of all beans including the configuration properties ones.

2. Moreover for the case when all bean's primary constructor arguments are bean injection then the bean<T>()  can be used and avoid the usage of an army of bean() calls. 

Apart from avoiding the proliferation of bean() calls, it also allows the injection of nullable bean, which is not straight forward with bean() which returns T: Any. See the commit changes related to this.

When there is a case of nullable bean (A), except for the case when there is not registerBean<A> in BeanRegistrarDsl? 
It is when a `ConfigurationProperties` (bean) is registered but when there is no entries in application.properties whatsoever.

A downside (so far) with the proposed changes is the fact that in IDEA the annotation `@ConfigurationProperties` is seen by Spring IDEA Spring support, and offers all the goodies that comes with this. But on the other hand the Kotlin Beans DSL was chosen for the beans registries, and it was expected to see all beans registration in (a hierarchy) of BeanRegistrarDsl.   