### PR TITLE
Rework Presentation states

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -104,7 +104,7 @@ internal class AppBeans :
         //
         // JOSE
         //
-        registerBean { CreateJarNimbus(bean(), bean<VerifierConfig>()) }
+        registerBean { CreateJarNimbus(bean()) }
         registerBean { VerifyEncryptedResponseWithNimbus(bean<VerifierConfig>().clientMetaData.responseEncryptionOption) }
 
         //

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/CreateJarNimbus.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/CreateJarNimbus.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.verifier.endpoint.adapter.out.jose
 
+import arrow.core.NonEmptyList
 import com.nimbusds.jose.*
 import com.nimbusds.jose.crypto.ECDHEncrypter
 import com.nimbusds.jose.crypto.RSAEncrypter
@@ -39,23 +40,30 @@ import eu.europa.ec.eudi.verifier.endpoint.domain.*
 import eu.europa.ec.eudi.verifier.endpoint.port.out.jose.CreateJar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlin.time.Instant
 import com.nimbusds.oauth2.sdk.ResponseMode as NimbusResponseMode
 
 /**
  * An implementation of [CreateJar] that uses Nimbus SDK
  */
 class CreateJarNimbus(
-    private val clock: Clock,
     private val verifierConfig: VerifierConfig,
 ) : CreateJar {
     override suspend fun invoke(
-        presentation: Presentation.Requested,
+        issuedAt: Instant,
+        transactionData: NonEmptyList<TransactionData>?,
+        channel: Channel,
+        query: DCQL,
+        nonce: Nonce,
         walletNonce: String?,
         walletJarEncryptionRequirement: EncryptionRequirement,
     ): Jwt =
         withContext(Dispatchers.Default) {
-            val requestObject = requestObjectFromDomain(verifierConfig, clock, presentation)
-            val responseMode = presentation.channel.responseMode
+            val requestObject =
+                context(verifierConfig) {
+                    requestObjectFromDomain(issuedAt, transactionData, channel, query, nonce)
+                }
+            val responseMode = channel.responseMode
             val signedJar = sign(responseMode, requestObject, walletNonce)
             when (walletJarEncryptionRequirement) {
                 EncryptionRequirement.NotRequired -> signedJar.serialize()

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/RequestObject.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/RequestObject.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.verifier.endpoint.adapter.out.jose
 
+import arrow.core.NonEmptyList
 import com.eygraber.uri.Url
 import eu.europa.ec.eudi.verifier.endpoint.domain.*
 import java.net.URL
@@ -35,47 +36,50 @@ internal data class RequestObject(
     val expectedOrigins: List<Url>? = null,
 )
 
+context(verifierConfig: VerifierConfig)
 internal fun requestObjectFromDomain(
-    verifierConfig: VerifierConfig,
-    clock: Clock,
-    presentation: Presentation.Requested,
+    issuedAt: Instant,
+    transactionData: NonEmptyList<TransactionData>?,
+    channel: Channel,
+    query: DCQL,
+    nonce: Nonce,
 ): RequestObject {
     val scope = emptyList<String>()
     val responseType = listOf(OpenId4VPSpec.VP_TOKEN)
-    val aud = listOf("https://self-issued.me/v2")
-    val transactionData = presentation.transactionData?.map { it.base64Url }
-    return when (val channel = presentation.channel) {
+    val audience = listOf("https://self-issued.me/v2")
+    val transactionData = transactionData?.map { it.base64Url }
+    return when (channel) {
         is Channel.OverDcApi -> {
             RequestObject(
                 verifierId = verifierConfig.verifierId,
                 scope = scope,
-                query = presentation.query,
+                query = query,
                 responseType = responseType,
-                audience = aud,
-                nonce = presentation.nonce.value,
+                audience = audience,
+                nonce = nonce.value,
                 state = null,
                 responseMode = OpenId4VPSpec.RESPONSE_MODE_DCAPI_JWT,
                 responseUri = null,
-                issuedAt = clock.now(),
+                issuedAt = issuedAt,
                 transactionData = transactionData,
                 expectedOrigins = listOf(channel.origin),
             )
         }
 
         is Channel.OverHttp -> {
-            when (presentation.channel.responseMode) {
+            when (channel.responseMode) {
                 ResponseMode.OverHttp.DirectPost -> {
                     RequestObject(
                         verifierId = verifierConfig.verifierId,
                         scope = scope,
-                        query = presentation.query,
+                        query = query,
                         responseType = responseType,
-                        audience = aud,
-                        nonce = presentation.nonce.value,
-                        state = presentation.channel.requestId.value,
+                        audience = audience,
+                        nonce = nonce.value,
+                        state = channel.requestId.value,
                         responseMode = OpenId4VPSpec.RESPONSE_MODE_DIRECT_POST,
-                        responseUri = verifierConfig.responseUriBuilder(presentation.channel.requestId),
-                        issuedAt = clock.now(),
+                        responseUri = verifierConfig.responseUriBuilder(channel.requestId),
+                        issuedAt = issuedAt,
                         transactionData = transactionData,
                         expectedOrigins = null,
                     )
@@ -85,14 +89,14 @@ internal fun requestObjectFromDomain(
                     RequestObject(
                         verifierId = verifierConfig.verifierId,
                         scope = scope,
-                        query = presentation.query,
+                        query = query,
                         responseType = responseType,
-                        audience = aud,
-                        nonce = presentation.nonce.value,
-                        state = presentation.channel.requestId.value,
+                        audience = audience,
+                        nonce = nonce.value,
+                        state = channel.requestId.value,
                         responseMode = OpenId4VPSpec.RESPONSE_MODE_DIRECT_POST_JWT,
-                        responseUri = verifierConfig.responseUriBuilder(presentation.channel.requestId),
-                        issuedAt = clock.now(),
+                        responseUri = verifierConfig.responseUriBuilder(channel.requestId),
+                        issuedAt = issuedAt,
                         transactionData = transactionData,
                         expectedOrigins = null,
                     )

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/Presentation.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/Presentation.kt
@@ -178,7 +178,7 @@ sealed interface Presentation {
     class Requested(
         override val id: TransactionId,
         override val initiatedAt: Instant,
-        override val channel: Channel,
+        override val channel: Channel.OverHttp,
         val query: DCQL,
         val transactionData: NonEmptyList<TransactionData>?,
         val nonce: Nonce,
@@ -192,7 +192,7 @@ sealed interface Presentation {
      * as part of the initialization of the process (when using request JAR parameter)
      * or later on (when using request_uri JAR parameter)
      */
-    class RequestObjectRetrieved private constructor(
+    class RequestObjectRetrieved(
         override val id: TransactionId,
         override val initiatedAt: Instant,
         override val channel: Channel,

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransaction.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransaction.kt
@@ -308,6 +308,14 @@ class InitTransactionLive(
 
         val issuerChain = issuerChain(initTransactionTO.issuerChain)
         val profile = initTransactionTO.profileOrDefault.toProfile()
+        val jarMode = jarMode(initTransactionTO)
+
+        // validate according to the selected profile
+        with(profile.validator) {
+            context(verifierConfig) {
+                validate(channel, jarMode)
+            }
+        }
 
         // Initialize presentation
         val requestedPresentation =
@@ -321,13 +329,6 @@ class InitTransactionLive(
                 profile = profile,
                 channel = channel,
             )
-
-        val jarMode = jarMode(initTransactionTO)
-
-        // validate according to the selected profile
-        with(profile.validator) {
-            validate(verifierConfig, requestedPresentation, jarMode)
-        }
 
         // create the request, which may update the presentation
         val (updatedPresentation, request) =
@@ -390,35 +391,44 @@ class InitTransactionLive(
                 origin = origin,
             )
 
-        // Initialize presentation
-        val requestedPresentation =
-            Presentation.Requested(
-                id = generateTransactionId(),
-                initiatedAt = clock.now(),
-                query = type.query,
-                transactionData = type.transactionData,
-                nonce = nonce,
-                issuerChain = issuerChain,
-                profile = profile,
-                channel = channel,
-            )
-
         // validate according to the selected profile
         with(profile.validator) {
-            validate(verifierConfig, requestedPresentation, jarMode)
+            context(verifierConfig) {
+                validate(channel, jarMode)
+            }
         }
 
-        val (updatedPresentation, jwt) =
-            createJarAndUpdatePresentation(
-                requestedPresentation,
+        // Initialize presentation
+        val requestedPresentation =
+            Presentation.RequestObjectRetrieved(
+                id = generateTransactionId(),
+                initiatedAt = clock.now(),
+                channel = channel,
+                query = type.query,
+                requestObjectRetrievedAt = clock.now(),
+                nonce = nonce,
+                transactionData = type.transactionData,
+                issuerChain = issuerChain,
+                profile = profile,
             )
 
-        storePresentation(updatedPresentation)
-        logTransactionInitialized(updatedPresentation, jwt)
+        val jwt =
+            createJar(
+                clock.now(),
+                requestedPresentation.transactionData,
+                requestedPresentation.channel,
+                requestedPresentation.query,
+                requestedPresentation.nonce,
+                null,
+                EncryptionRequirement.NotRequired,
+            )
+
+        storePresentation(requestedPresentation)
+        logTransactionInitialized(requestedPresentation, jwt)
 
         return InitDcApiTransactionResponseTO(
             jwt,
-            updatedPresentation.id.value,
+            requestedPresentation.id.value,
         )
     }
 
@@ -437,7 +447,17 @@ class InitTransactionLive(
     ): Pair<Presentation, InitTransactionResponse.JwtSecuredAuthorizationRequestTO> =
         when (requestJarOption) {
             is EmbedOption.ByValue -> {
-                val (requestObjectRetrieved, jwt) = createJarAndUpdatePresentation(requestedPresentation)
+                val jwt =
+                    createJar(
+                        clock.now(),
+                        requestedPresentation.transactionData,
+                        requestedPresentation.channel,
+                        requestedPresentation.query,
+                        requestedPresentation.nonce,
+                        null,
+                        EncryptionRequirement.NotRequired,
+                    )
+                val requestObjectRetrieved = requestedPresentation.retrieveRequestObject(clock)
                 requestObjectRetrieved to
                     InitTransactionResponse.JwtSecuredAuthorizationRequestTO.byValue(
                         requestedPresentation.id.value,
@@ -448,10 +468,7 @@ class InitTransactionLive(
             }
 
             is EmbedOption.ByReference -> {
-                check(requestedPresentation.channel is Channel.OverHttp)
-
                 val requestUri = requestJarOption.buildUrl(requestedPresentation.channel.requestId)
-
                 requestedPresentation to
                     InitTransactionResponse.JwtSecuredAuthorizationRequestTO.byReference(
                         requestedPresentation.id.value,
@@ -479,20 +496,6 @@ class InitTransactionLive(
             RequestUriMethodTO.PostOrGet -> RequestUriMethod.PostOrGet
             null -> verifierConfig.requestUriMethod
         }
-
-    private suspend fun createJarAndUpdatePresentation(
-        requestedPresentation: Presentation.Requested,
-    ): Pair<Presentation.RequestObjectRetrieved, Jwt> {
-        val jwt =
-            createJar(
-                requestedPresentation,
-                null,
-                EncryptionRequirement.NotRequired,
-            )
-
-        val requestObjectRetrieved = requestedPresentation.retrieveRequestObject(clock)
-        return requestObjectRetrieved to jwt
-    }
 
     context(_: Raise<ValidationError>)
     private fun getWalletResponseMethod(redirectUriTemplate: String?): GetWalletResponseMethod =
@@ -687,17 +690,17 @@ private fun <T : Any, U : T> Collection<T>.containsAny(
 ): Boolean = first in this || rest.any { it in this }
 
 private fun interface ProfileValidator {
-    context(_: Raise<ValidationError>)
+    context(_: Raise<ValidationError>, config: VerifierConfig)
     suspend fun validate(
-        config: VerifierConfig,
-        presentation: Presentation.Requested,
+        channel: Channel,
         jarMode: EmbedOption<RequestId>,
     )
 
     companion object {
-        val OpenId4VP = ProfileValidator { _, _, _ -> }
+        val OpenId4VP = ProfileValidator { _, _ -> }
         val HAIP =
-            ProfileValidator { config, presentation, jarMode ->
+            ProfileValidator { channel, jarMode ->
+                val config = contextOf<VerifierConfig>()
                 with(config.clientMetaData.vpFormatsSupported) {
                     ensure(null != sdJwtVc || null != msoMdoc) {
                         ValidationError.HaipNotSupported.SdJwtVcOrMsoMdocMustBeSupported
@@ -748,7 +751,7 @@ private fun interface ProfileValidator {
                 ) {
                     ValidationError.HaipNotSupported.SelfSignedCertificateMustNotBeUsed
                 }
-                when (presentation.channel) {
+                when (channel) {
                     is Channel.OverDcApi -> {
                         ensure(jarMode is EmbedOption.ByValue) {
                             ValidationError.HaipNotSupported.AuthorizationRequestMustBeProvidedByReference
@@ -756,7 +759,7 @@ private fun interface ProfileValidator {
                     }
 
                     is Channel.OverHttp -> {
-                        ensure(presentation.channel.responseMode is DirectPostJwt) {
+                        ensure(channel.responseMode is DirectPostJwt) {
                             ValidationError.HaipNotSupported.ResponseModeDirectPostJwtMustBeUsed
                         }
                         ensure(jarMode is EmbedOption.ByReference) {
@@ -767,8 +770,8 @@ private fun interface ProfileValidator {
             }
 
         val ETSI119472Part2 =
-            ProfileValidator { config, presentation, jarMode ->
-                HAIP.validate(config, presentation, jarMode)
+            ProfileValidator { channel, jarMode ->
+                HAIP.validate(channel, jarMode)
             }
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransaction.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransaction.kt
@@ -330,86 +330,16 @@ class InitTransactionLive(
 
         // Initialize presentation
         val (presentation, authorizationRequest) =
-            when (jarMode) {
-                is EmbedOption.ByReference -> {
-                    val presentation =
-                        Presentation.Requested(
-                            id = generateTransactionId(),
-                            initiatedAt = clock.now(),
-                            query = type.query,
-                            transactionData = type.transactionData,
-                            nonce = nonce,
-                            issuerChain = issuerChain,
-                            profile = profile,
-                            channel = channel,
-                        )
-
-                    val requestUri = jarMode.buildUrl(presentation.channel.requestId)
-                    val authorizationRequest =
-                        InitTransactionResponse.JwtSecuredAuthorizationRequestTO.byReference(
-                            presentation.id.value,
-                            verifierConfig.verifierId.clientId,
-                            requestUri,
-                            presentation.channel.requestUriMethod.toTO(),
-                            unresolvedAuthorizationRequestUri
-                                .resolve(
-                                    verifierConfig.verifierId,
-                                    Uri.parse(requestUri.toString()),
-                                    presentation.channel.requestUriMethod,
-                                ).toURI(),
-                        )
-                    presentation to authorizationRequest
-                }
-
-                EmbedOption.ByValue -> {
-                    val presentation =
-                        Presentation.RequestObjectRetrieved(
-                            id = generateTransactionId(),
-                            initiatedAt = clock.now(),
-                            channel = channel,
-                            query = type.query,
-                            transactionData = type.transactionData,
-                            requestObjectRetrievedAt = clock.now(),
-                            nonce = nonce,
-                            issuerChain = issuerChain,
-                            profile = profile,
-                        )
-
-                    val jar =
-                        createJar(
-                            clock.now(),
-                            presentation.transactionData,
-                            presentation.channel,
-                            presentation.query,
-                            presentation.nonce,
-                            null,
-                            EncryptionRequirement.NotRequired,
-                        )
-                    val authorizationRequest =
-                        InitTransactionResponse.JwtSecuredAuthorizationRequestTO.byValue(
-                            presentation.id.value,
-                            verifierConfig.verifierId.clientId,
-                            jar,
-                            unresolvedAuthorizationRequestUri.resolve(verifierConfig.verifierId, jar).toURI(),
-                        )
-                    presentation to authorizationRequest
-                }
-            }
-
-        val response =
-            when (initTransactionTO.output) {
-                Output.Json -> {
-                    authorizationRequest
-                }
-
-                Output.QrCode -> {
-                    InitTransactionResponse.QrCode(
-                        generateQrCode(authorizationRequest.authorizationRequestUri, size = (250.pixels by 250.pixels)),
-                        authorizationRequest.transactionId,
-                        authorizationRequest.authorizationRequestUri,
-                    )
-                }
-            }
+            createPresentationAndAuthorizationRequest(
+                jarMode,
+                type,
+                nonce,
+                issuerChain,
+                profile,
+                channel,
+                unresolvedAuthorizationRequestUri,
+            )
+        val response = initTransactionTO.output.createResponse(authorizationRequest)
 
         storePresentation(presentation)
         logTransactionInitialized(presentation, authorizationRequest, profile)
@@ -484,6 +414,98 @@ class InitTransactionLive(
             requestedPresentation.id.value,
         )
     }
+
+    private suspend fun createPresentationAndAuthorizationRequest(
+        jarMode: EmbedOption<RequestId>,
+        type: VpTokenRequest,
+        nonce: Nonce,
+        issuerChain: NonEmptyList<X509Certificate>?,
+        profile: Profile,
+        channel: Channel.OverHttp,
+        unresolvedAuthorizationRequestUri: UnresolvedAuthorizationRequestUri,
+    ): Pair<Presentation, InitTransactionResponse.JwtSecuredAuthorizationRequestTO> =
+        when (jarMode) {
+            is EmbedOption.ByReference -> {
+                val presentation =
+                    Presentation.Requested(
+                        id = generateTransactionId(),
+                        initiatedAt = clock.now(),
+                        query = type.query,
+                        transactionData = type.transactionData,
+                        nonce = nonce,
+                        issuerChain = issuerChain,
+                        profile = profile,
+                        channel = channel,
+                    )
+
+                val requestUri = jarMode.buildUrl(presentation.channel.requestId)
+                val authorizationRequest =
+                    InitTransactionResponse.JwtSecuredAuthorizationRequestTO.byReference(
+                        presentation.id.value,
+                        verifierConfig.verifierId.clientId,
+                        requestUri,
+                        presentation.channel.requestUriMethod.toTO(),
+                        unresolvedAuthorizationRequestUri
+                            .resolve(
+                                verifierConfig.verifierId,
+                                Uri.parse(requestUri.toString()),
+                                presentation.channel.requestUriMethod,
+                            ).toURI(),
+                    )
+                presentation to authorizationRequest
+            }
+
+            EmbedOption.ByValue -> {
+                val presentation =
+                    Presentation.RequestObjectRetrieved(
+                        id = generateTransactionId(),
+                        initiatedAt = clock.now(),
+                        channel = channel,
+                        query = type.query,
+                        transactionData = type.transactionData,
+                        requestObjectRetrievedAt = clock.now(),
+                        nonce = nonce,
+                        issuerChain = issuerChain,
+                        profile = profile,
+                    )
+
+                val jar =
+                    createJar(
+                        clock.now(),
+                        presentation.transactionData,
+                        presentation.channel,
+                        presentation.query,
+                        presentation.nonce,
+                        null,
+                        EncryptionRequirement.NotRequired,
+                    )
+                val authorizationRequest =
+                    InitTransactionResponse.JwtSecuredAuthorizationRequestTO.byValue(
+                        presentation.id.value,
+                        verifierConfig.verifierId.clientId,
+                        jar,
+                        unresolvedAuthorizationRequestUri.resolve(verifierConfig.verifierId, jar).toURI(),
+                    )
+                presentation to authorizationRequest
+            }
+        }
+
+    private suspend fun Output.createResponse(
+        authorizationRequest: InitTransactionResponse.JwtSecuredAuthorizationRequestTO,
+    ): InitTransactionResponse =
+        when (this) {
+            Output.Json -> {
+                authorizationRequest
+            }
+
+            Output.QrCode -> {
+                InitTransactionResponse.QrCode(
+                    generateQrCode(authorizationRequest.authorizationRequestUri, size = (250.pixels by 250.pixels)),
+                    authorizationRequest.transactionId,
+                    authorizationRequest.authorizationRequestUri,
+                )
+            }
+        }
 
     /**
      * Gets the JAR [RequestUriMethod] for the provided [InitTransactionTO].

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransaction.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransaction.kt
@@ -382,7 +382,7 @@ class InitTransactionLive(
         }
 
         // Initialize presentation
-        val requestedPresentation =
+        val presentation =
             Presentation.RequestObjectRetrieved(
                 id = generateTransactionId(),
                 initiatedAt = clock.now(),
@@ -395,23 +395,23 @@ class InitTransactionLive(
                 profile = profile,
             )
 
-        val jwt =
+        val jar =
             createJar(
                 clock.now(),
-                requestedPresentation.transactionData,
-                requestedPresentation.channel,
-                requestedPresentation.query,
-                requestedPresentation.nonce,
+                presentation.transactionData,
+                presentation.channel,
+                presentation.query,
+                presentation.nonce,
                 null,
                 EncryptionRequirement.NotRequired,
             )
 
-        storePresentation(requestedPresentation)
-        logTransactionInitialized(requestedPresentation, jwt)
+        storePresentation(presentation)
+        logTransactionInitialized(presentation, jar)
 
         return InitDcApiTransactionResponseTO(
-            jwt,
-            requestedPresentation.id.value,
+            jar,
+            presentation.id.value,
         )
     }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransaction.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransaction.kt
@@ -32,6 +32,8 @@ import com.nimbusds.jose.JWSAlgorithm
 import eu.europa.ec.eudi.verifier.endpoint.adapter.out.json.decodeAs
 import eu.europa.ec.eudi.verifier.endpoint.adapter.out.x509.isSelfSigned
 import eu.europa.ec.eudi.verifier.endpoint.domain.*
+import eu.europa.ec.eudi.verifier.endpoint.domain.EmbedOption
+import eu.europa.ec.eudi.verifier.endpoint.domain.EncryptionRequirement
 import eu.europa.ec.eudi.verifier.endpoint.domain.ResponseMode.OverDcApi.*
 import eu.europa.ec.eudi.verifier.endpoint.domain.ResponseMode.OverHttp.*
 import eu.europa.ec.eudi.verifier.endpoint.port.out.cfg.CreateQueryWalletResponseRedirectUri
@@ -317,49 +319,100 @@ class InitTransactionLive(
             }
         }
 
-        // Initialize presentation
-        val requestedPresentation =
-            Presentation.Requested(
-                id = generateTransactionId(),
-                initiatedAt = clock.now(),
-                query = type.query,
-                transactionData = type.transactionData,
-                nonce = nonce,
-                issuerChain = issuerChain,
-                profile = profile,
-                channel = channel,
-            )
-
         // create the request, which may update the presentation
-        val (updatedPresentation, request) =
-            createRequest(
-                requestedPresentation,
-                jarMode,
-                with(verifierConfig) {
-                    authorizationRequestUri(
-                        initTransactionTO.authorizationRequestUri,
-                        initTransactionTO.authorizationRequestScheme,
-                    )
-                },
-            )
+        val unresolvedAuthorizationRequestUri =
+            with(verifierConfig) {
+                authorizationRequestUri(
+                    initTransactionTO.authorizationRequestUri,
+                    initTransactionTO.authorizationRequestScheme,
+                )
+            }
+
+        // Initialize presentation
+        val (presentation, authorizationRequest) =
+            when (jarMode) {
+                is EmbedOption.ByReference -> {
+                    val presentation =
+                        Presentation.Requested(
+                            id = generateTransactionId(),
+                            initiatedAt = clock.now(),
+                            query = type.query,
+                            transactionData = type.transactionData,
+                            nonce = nonce,
+                            issuerChain = issuerChain,
+                            profile = profile,
+                            channel = channel,
+                        )
+
+                    val requestUri = jarMode.buildUrl(presentation.channel.requestId)
+                    val authorizationRequest =
+                        InitTransactionResponse.JwtSecuredAuthorizationRequestTO.byReference(
+                            presentation.id.value,
+                            verifierConfig.verifierId.clientId,
+                            requestUri,
+                            presentation.channel.requestUriMethod.toTO(),
+                            unresolvedAuthorizationRequestUri
+                                .resolve(
+                                    verifierConfig.verifierId,
+                                    Uri.parse(requestUri.toString()),
+                                    presentation.channel.requestUriMethod,
+                                ).toURI(),
+                        )
+                    presentation to authorizationRequest
+                }
+
+                EmbedOption.ByValue -> {
+                    val presentation =
+                        Presentation.RequestObjectRetrieved(
+                            id = generateTransactionId(),
+                            initiatedAt = clock.now(),
+                            channel = channel,
+                            query = type.query,
+                            transactionData = type.transactionData,
+                            requestObjectRetrievedAt = clock.now(),
+                            nonce = nonce,
+                            issuerChain = issuerChain,
+                            profile = profile,
+                        )
+
+                    val jar =
+                        createJar(
+                            clock.now(),
+                            presentation.transactionData,
+                            presentation.channel,
+                            presentation.query,
+                            presentation.nonce,
+                            null,
+                            EncryptionRequirement.NotRequired,
+                        )
+                    val authorizationRequest =
+                        InitTransactionResponse.JwtSecuredAuthorizationRequestTO.byValue(
+                            presentation.id.value,
+                            verifierConfig.verifierId.clientId,
+                            jar,
+                            unresolvedAuthorizationRequestUri.resolve(verifierConfig.verifierId, jar).toURI(),
+                        )
+                    presentation to authorizationRequest
+                }
+            }
 
         val response =
             when (initTransactionTO.output) {
                 Output.Json -> {
-                    request
+                    authorizationRequest
                 }
 
                 Output.QrCode -> {
                     InitTransactionResponse.QrCode(
-                        generateQrCode(request.authorizationRequestUri, size = (250.pixels by 250.pixels)),
-                        request.transactionId,
-                        request.authorizationRequestUri,
+                        generateQrCode(authorizationRequest.authorizationRequestUri, size = (250.pixels by 250.pixels)),
+                        authorizationRequest.transactionId,
+                        authorizationRequest.authorizationRequestUri,
                     )
                 }
             }
 
-        storePresentation(updatedPresentation)
-        logTransactionInitialized(updatedPresentation, request, profile)
+        storePresentation(presentation)
+        logTransactionInitialized(presentation, authorizationRequest, profile)
 
         return response
     }
@@ -431,59 +484,6 @@ class InitTransactionLive(
             requestedPresentation.id.value,
         )
     }
-
-    /**
-     * Creates a request and depending on the case updates also the [requestedPresentation]
-     *
-     * If the [requestJarOption] or the verifier has been configured to use request parameter then
-     * presentation will be updated to [Presentation.RequestObjectRetrieved].
-     *
-     * Otherwise, [requestedPresentation] will remain as is
-     */
-    private suspend fun createRequest(
-        requestedPresentation: Presentation.Requested,
-        requestJarOption: EmbedOption<RequestId>,
-        authorizationRequestUri: UnresolvedAuthorizationRequestUri,
-    ): Pair<Presentation, InitTransactionResponse.JwtSecuredAuthorizationRequestTO> =
-        when (requestJarOption) {
-            is EmbedOption.ByValue -> {
-                val jwt =
-                    createJar(
-                        clock.now(),
-                        requestedPresentation.transactionData,
-                        requestedPresentation.channel,
-                        requestedPresentation.query,
-                        requestedPresentation.nonce,
-                        null,
-                        EncryptionRequirement.NotRequired,
-                    )
-                val requestObjectRetrieved = requestedPresentation.retrieveRequestObject(clock)
-                requestObjectRetrieved to
-                    InitTransactionResponse.JwtSecuredAuthorizationRequestTO.byValue(
-                        requestedPresentation.id.value,
-                        verifierConfig.verifierId.clientId,
-                        jwt,
-                        authorizationRequestUri.resolve(verifierConfig.verifierId, jwt).toURI(),
-                    )
-            }
-
-            is EmbedOption.ByReference -> {
-                val requestUri = requestJarOption.buildUrl(requestedPresentation.channel.requestId)
-                requestedPresentation to
-                    InitTransactionResponse.JwtSecuredAuthorizationRequestTO.byReference(
-                        requestedPresentation.id.value,
-                        verifierConfig.verifierId.clientId,
-                        requestUri,
-                        requestedPresentation.channel.requestUriMethod.toTO(),
-                        authorizationRequestUri
-                            .resolve(
-                                verifierConfig.verifierId,
-                                Uri.parse(requestUri.toString()),
-                                requestedPresentation.channel.requestUriMethod,
-                            ).toURI(),
-                    )
-            }
-        }
 
     /**
      * Gets the JAR [RequestUriMethod] for the provided [InitTransactionTO].

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/RetrieveRequestObject.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/RetrieveRequestObject.kt
@@ -148,13 +148,19 @@ class RetrieveRequestObjectLive(
             RetrieveRequestObjectError.InvalidState(Presentation.Requested::class, presentation::class)
         }
 
-        check(presentation.channel is Channel.OverHttp)
-
         suspend fun updatePresentationAndCreateJar(
             encryptionRequirement: EncryptionRequirement,
         ): Pair<Presentation.RequestObjectRetrieved, Jwt> {
             val jar =
-                createJar(presentation, method.walletNonceOrNull, encryptionRequirement)
+                createJar(
+                    clock.now(),
+                    presentation.transactionData,
+                    presentation.channel,
+                    presentation.query,
+                    presentation.nonce,
+                    method.walletNonceOrNull,
+                    encryptionRequirement,
+                )
             val updatedPresentation = presentation.retrieveRequestObject(clock)
             storePresentation(updatedPresentation)
             return updatedPresentation to jar
@@ -299,8 +305,6 @@ private class WalletMetadataValidator(
         metadata: WalletMetadataTO,
         presentation: Presentation.Requested,
     ) {
-        check(presentation.channel is Channel.OverHttp)
-
         val responseMode =
             presentation.channel.responseMode.option
                 .name()

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/out/jose/CreateJar.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/out/jose/CreateJar.kt
@@ -15,16 +15,20 @@
  */
 package eu.europa.ec.eudi.verifier.endpoint.port.out.jose
 
-import eu.europa.ec.eudi.verifier.endpoint.domain.EncryptionRequirement
-import eu.europa.ec.eudi.verifier.endpoint.domain.Jwt
-import eu.europa.ec.eudi.verifier.endpoint.domain.Presentation
+import arrow.core.NonEmptyList
+import eu.europa.ec.eudi.verifier.endpoint.domain.*
+import kotlin.time.Instant
 
 /**
  * An out port that signs and encrypts a [Presentation.Requested]
  */
 fun interface CreateJar {
     suspend operator fun invoke(
-        presentation: Presentation.Requested,
+        issuedAt: Instant,
+        transactionData: NonEmptyList<TransactionData>?,
+        channel: Channel,
+        query: DCQL,
+        nonce: Nonce,
         walletNonce: String?,
         walletJarEncryptionRequirement: EncryptionRequirement,
     ): Jwt

--- a/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/TestContext.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/TestContext.kt
@@ -96,7 +96,7 @@ object TestContext {
             generatedTransactionId,
             generateRequestId,
             storePresentation,
-            CreateJarNimbus(testClock, verifierConfig),
+            CreateJarNimbus(verifierConfig),
             verifierConfig,
             testClock,
             generateEphemeralKey,

--- a/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/CreateJarNimbusTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/CreateJarNimbusTest.kt
@@ -67,7 +67,7 @@ class CreateJarNimbusTest {
             authorizationRequestUri = UnresolvedAuthorizationRequestUri.fromUri("haip-vp://").getOrThrow(),
         )
 
-    private val createJar = CreateJarNimbus(TestContext.testClock, verifierConfig)
+    private val createJar = CreateJarNimbus(verifierConfig)
 
     @Test
     fun `given a request object, it should be signed and decoded`() {


### PR DESCRIPTION
HTTP authorization requests can be sent either by value or by reference.
On the other hand, DC API authorization requests are always sent by value.

The state `Presentation.Requested` is used for transactions the authorization request of which is to be sent by reference.
Thus its `Channel` cannot be anything other than `Channel.OverHttp`. 
This is also supported by the fact that we have several `checks` in the code which assert that `channel` is `Channel.OverHttp` when `Presentation.Requested` is at hand.

DC API transactions cannot be initialized in this state, and must be initialized in `Presentation.RequestObjectRetrieved` instead.

This PR updates the code so that DC API transactions are initialized in `Presentation.RequestObjectRetrieved` state, and updates `ProfileValidator` and `CreateJar` to instead accept the needed parameters over `Presentation.Requested`.

Finally this PR updates the initialization of HTTP transactions so that they are initialized directly in the appropriate state. i.e. HTTP transactions that are by value are no longer initially create in `Presentation.Requested` state and then transitioned to `Presentation.RequestObjectRetrieved`, but rather directly in `Presentation.RequestObjectRetrieved`.